### PR TITLE
Remove GQuark from SymbolTable

### DIFF
--- a/src/Gir/Marshal/SymbolTable.Builtin.cs
+++ b/src/Gir/Marshal/SymbolTable.Builtin.cs
@@ -41,7 +41,6 @@ namespace Gir
 			AddType(new Primitive("gdouble", "double", "0.0"));
 			AddType(new Primitive("double", "double", "0.0"));
 			AddType(new Primitive("goffset", "long", "0"));
-			AddType(new Primitive("GQuark", "int", "0"));
 		}
 
 	}


### PR DESCRIPTION
This one is aliased in GLib-2.0.gir to guint32