### PR TITLE
[Gen] Add simple Record generation

### DIFF
--- a/src/Gir.Tests/BitFieldTests.cs
+++ b/src/Gir.Tests/BitFieldTests.cs
@@ -24,16 +24,22 @@ namespace Gir.Tests
 	{
 		///<summary>the font family is specified.</summary>
 		Family = 0x1,
+
 		///<summary>the font style is specified.</summary>
 		Style = 0x2,
+
 		///<summary>the font variant is specified.</summary>
 		Variant = 0x4,
+
 		///<summary>the font weight is specified.</summary>
 		Weight = 0x8,
+
 		///<summary>the font stretch is specified.</summary>
 		Stretch = 0x10,
+
 		///<summary>the font size is specified.</summary>
 		Size = 0x20,
+
 		///<summary>the font gravity is specified (Since: 1.16.)</summary>
 		Gravity = 0x40,
 	}

--- a/src/Gir.Tests/EnumerationTests.cs
+++ b/src/Gir.Tests/EnumerationTests.cs
@@ -25,8 +25,10 @@ namespace Gir.Tests
 	{
 		///<summary>Put all available space on the right</summary>
 		Left = 0,
+
 		///<summary>Center the line within the available space</summary>
 		Center = 1,
+
 		///<summary>Put all available space on the left</summary>
 		Right = 2,
 	}

--- a/src/Gir.Tests/GenerationOptionsTests.cs
+++ b/src/Gir.Tests/GenerationOptionsTests.cs
@@ -23,8 +23,10 @@ namespace Gir.Tests
 	{
 		///<summary>Put all available space on the right</summary>
 		Left = 0,
+
 		///<summary>Center the line within the available space</summary>
 		Center = 1,
+
 		///<summary>Put all available space on the left</summary>
 		Right = 2,
 	}

--- a/src/Gir.Tests/Gir.Tests.csproj
+++ b/src/Gir.Tests/Gir.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="GenerationOptionsTests.cs" />
     <Compile Include="BitFieldTests.cs" />
     <Compile Include="SymbolTableTests.cs" />
+    <Compile Include="RecordTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="TestFiles\" />

--- a/src/Gir.Tests/RecordTests.cs
+++ b/src/Gir.Tests/RecordTests.cs
@@ -10,23 +10,24 @@ namespace Gir.Tests
 		public void TestRecordIsGenerated()
 		{
 			// Test is incomplete, as record is not fully generated atm.
-			var result = GenerateType(GLib, "Array");
+			var result = GenerateType(GLib, "ByteArray");
 
+
+			// Need to map pointers at symbol level.
+			Console.WriteLine(result);
 			Assert.AreEqual(@"namespace GLib
 {
-	///<summary>Contains the public fields of a GArray.</summary>
-	public struct Array
+	///<summary>Contains the public fields of a GByteArray.</summary>
+	public struct ByteArray
 	{
 		///<summary>
 		/// a pointer to the element data. The data may be moved as
-		///     elements are added to the #GArray.
+		///     elements are added to the #GByteArray
 		///</summary>
-		utf8 data;
-		///<summary>
-		/// the number of elements in the #GArray not including the
-		///     possible terminating zero element.
-		///</summary>
-		guint len;
+		byte data;
+
+		///<summary>the number of elements in the #GByteArray</summary>
+		uint len;
 	}
 }
 ", result);

--- a/src/Gir.Tests/RecordTests.cs
+++ b/src/Gir.Tests/RecordTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Gir.Tests
+{
+	[TestFixture]
+	public class RecordTests : GenerationTestBase
+	{
+		[Test]
+		public void TestRecordIsGenerated()
+		{
+			// Test is incomplete, as record is not fully generated atm.
+			var result = GenerateType(GLib, "Array");
+
+			Assert.AreEqual(@"namespace GLib
+{
+	///<summary>Contains the public fields of a GArray.</summary>
+	public struct Array
+	{
+		///<summary>
+		/// a pointer to the element data. The data may be moved as
+		///     elements are added to the #GArray.
+		///</summary>
+		utf8 data;
+		///<summary>
+		/// the number of elements in the #GArray not including the
+		///     possible terminating zero element.
+		///</summary>
+		guint len;
+	}
+}
+", result);
+		}
+	}
+}

--- a/src/Gir/Generation/Bitfield.cs
+++ b/src/Gir/Generation/Bitfield.cs
@@ -17,7 +17,7 @@ namespace Gir
 					writer.WriteLine("{");
 
 					using (writer.Indent()) {
-						this.GenerateMembers(writer);
+						this.GenerateMembers(opts, writer);
 					}
 					writer.WriteLine("}");
 				}

--- a/src/Gir/Generation/Bitfield.cs
+++ b/src/Gir/Generation/Bitfield.cs
@@ -17,28 +17,12 @@ namespace Gir
 					writer.WriteLine("{");
 
 					using (writer.Indent()) {
-						GenerateMembers(writer);
+						this.GenerateMembers(writer);
 					}
 					writer.WriteLine("}");
 				}
 				writer.WriteLine("}");
 			}
-		}
-
-		void GenerateMembers(IndentWriter writer)
-		{
-			foreach (var member in Members) {
-				writer.WriteDocumentation(member.Doc);
-				writer.WriteLine(member.Name.ToCSharp() + " = " + HexFormat(member.Value) + ",");
-			}
-		}
-
-		string HexFormat(string text)
-		{
-			int value = int.Parse(text);
-
-			// Maybe pad with leading zeroes based on the value?
-			return string.Format("0x{0:X}", value);
 		}
 	}
 }

--- a/src/Gir/Generation/Enumeration.cs
+++ b/src/Gir/Generation/Enumeration.cs
@@ -16,7 +16,7 @@ namespace Gir
 					writer.WriteLine("{");
 
 					using (writer.Indent()) {
-						this.GenerateMembers(writer);
+						this.GenerateMembers(opts, writer);
 					}
 					writer.WriteLine("}");
 				}

--- a/src/Gir/Generation/Field.cs
+++ b/src/Gir/Generation/Field.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace Gir
+{
+	public partial class Field : IMemberGeneratable
+	{
+		public void Generate(IGeneratable parent, IndentWriter writer)
+		{
+			writer.WriteDocumentation(Doc);
+			// Simple uncorrect gen for now
+			writer.WriteLine($"{Type.Name} {Name};");
+		}
+	}
+}

--- a/src/Gir/Generation/Field.cs
+++ b/src/Gir/Generation/Field.cs
@@ -3,11 +3,23 @@ namespace Gir
 {
 	public partial class Field : IMemberGeneratable
 	{
-		public void Generate(IGeneratable parent, IndentWriter writer)
+		public void Generate(GenerationOptions opts, IGeneratable parent, IndentWriter writer)
 		{
 			writer.WriteDocumentation(Doc);
+
 			// Simple uncorrect gen for now
-			writer.WriteLine($"{Type.Name} {Name};");
+			var managedType = this.GetSymbol(opts);
+
+			// We need something that will tell us the equivalent C# type
+			// including the number of pointers.
+			// For now, generate normal info.
+
+			writer.WriteLine($"{managedType.Name} {Name};");
+		}
+
+		public bool NewlineAfterGeneration(GenerationOptions opts)
+		{
+			return true;
 		}
 	}
 }

--- a/src/Gir/Generation/IGeneratable.cs
+++ b/src/Gir/Generation/IGeneratable.cs
@@ -3,10 +3,17 @@ using System.Text;
 
 namespace Gir
 {
+	// Top level generation capability
 	public interface IGeneratable
 	{
 		string Name { get; }
 		//void Process();
 		void Generate(GenerationOptions opts);
+	}
+
+	// When generated as part of another generatable
+	public interface IMemberGeneratable
+	{
+		void Generate(IGeneratable parent, IndentWriter writer);
 	}
 }

--- a/src/Gir/Generation/IGeneratable.cs
+++ b/src/Gir/Generation/IGeneratable.cs
@@ -14,6 +14,7 @@ namespace Gir
 	// When generated as part of another generatable
 	public interface IMemberGeneratable
 	{
-		void Generate(IGeneratable parent, IndentWriter writer);
+		bool NewlineAfterGeneration(GenerationOptions opts);
+		void Generate(GenerationOptions opts, IGeneratable parent, IndentWriter writer);
 	}
 }

--- a/src/Gir/Generation/IGeneratableExtensions.cs
+++ b/src/Gir/Generation/IGeneratableExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Gir
@@ -11,6 +12,19 @@ namespace Gir
 		{
 			var path = Path.Combine(opts.DirectoryPath, gen.Name + CSharpFileExtension);
 			return IndentWriter.OpenWrite(path, opts);
+		}
+
+		public static void GenerateMembers (this IGeneratable gen, IndentWriter writer)
+		{
+			foreach (var member in gen.GetMemberGeneratables())
+			{
+				member.Generate(gen, writer);
+			}
+		}
+
+		static IEnumerable<IMemberGeneratable> GetMemberGeneratables (this IGeneratable gen)
+		{
+			return Utils.GetAllCollectionMembers<IMemberGeneratable>(gen);
 		}
 	}
 }

--- a/src/Gir/Generation/IGeneratableExtensions.cs
+++ b/src/Gir/Generation/IGeneratableExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Gir
 {
@@ -14,11 +15,15 @@ namespace Gir
 			return IndentWriter.OpenWrite(path, opts);
 		}
 
-		public static void GenerateMembers (this IGeneratable gen, IndentWriter writer)
+		public static void GenerateMembers (this IGeneratable gen, GenerationOptions opts, IndentWriter writer)
 		{
-			foreach (var member in gen.GetMemberGeneratables())
-			{
-				member.Generate(gen, writer);
+			var array = gen.GetMemberGeneratables().ToArray ();
+			for (int i = 0; i < array.Length; ++i) {
+				var member = array[i];
+				member.Generate(opts, gen, writer);
+
+				if (i != array.Length - 1 && member.NewlineAfterGeneration (opts))
+					writer.WriteLine();
 			}
 		}
 

--- a/src/Gir/Generation/Member.cs
+++ b/src/Gir/Generation/Member.cs
@@ -3,7 +3,12 @@ namespace Gir
 {
 	public partial class Member : IMemberGeneratable
 	{
-		public void Generate(IGeneratable parent, IndentWriter writer)
+		public bool NewlineAfterGeneration(GenerationOptions opts)
+		{
+			return opts.GenerateDocumentation;
+		}
+
+		public void Generate(GenerationOptions opts, IGeneratable parent, IndentWriter writer)
 		{
 			writer.WriteDocumentation(Doc);
 

--- a/src/Gir/Generation/Member.cs
+++ b/src/Gir/Generation/Member.cs
@@ -1,0 +1,26 @@
+﻿using System;
+namespace Gir
+{
+	public partial class Member : IMemberGeneratable
+	{
+		public void Generate(IGeneratable parent, IndentWriter writer)
+		{
+			writer.WriteDocumentation(Doc);
+
+			string value = Value;
+			// Make this smarter, probably pass in some options and key them.
+			if (parent is Bitfield)
+				value = HexFormat(value);
+
+			writer.WriteLine(Name.ToCSharp() + " = " + value + ",");
+		}
+
+		string HexFormat(string text)
+		{
+			int value = int.Parse(text);
+
+			// Maybe pad with leading zeroes based on the value?
+			return string.Format("0x{0:X}", value);
+		}
+	}
+}

--- a/src/Gir/Generation/Record.cs
+++ b/src/Gir/Generation/Record.cs
@@ -14,7 +14,7 @@ namespace Gir
 					writer.WriteLine("{");
 
 					using (writer.Indent()) {
-						this.GenerateMembers(writer);
+						this.GenerateMembers(opts, writer);
 					}
 					writer.WriteLine("}");
 				}

--- a/src/Gir/Generation/Record.cs
+++ b/src/Gir/Generation/Record.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.IO;
-
 namespace Gir
 {
-	public partial class Enumeration : IGeneratable
+	public partial class Record : IGeneratable
 	{
 		public void Generate(GenerationOptions opts)
 		{
@@ -12,7 +10,7 @@ namespace Gir
 				writer.WriteLine("{");
 				using (writer.Indent()) {
 					writer.WriteDocumentation(Doc);
-					writer.WriteLine("public enum " + Name);
+					writer.WriteLine("public struct " + Name);
 					writer.WriteLine("{");
 
 					using (writer.Indent()) {

--- a/src/Gir/Gir.csproj
+++ b/src/Gir/Gir.csproj
@@ -99,6 +99,9 @@
     <Compile Include="Generation\Record.cs" />
     <Compile Include="Generation\Member.cs" />
     <Compile Include="Generation\Field.cs" />
+    <Compile Include="Marshal\Type.cs" />
+    <Compile Include="Marshal\IHasType.cs" />
+    <Compile Include="Marshal\Field.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Schema\c.xsd" />

--- a/src/Gir/Gir.csproj
+++ b/src/Gir/Gir.csproj
@@ -95,6 +95,10 @@
     <Compile Include="Error.cs" />
     <Compile Include="Marshal\SymbolTable.RegistrationError.cs" />
     <Compile Include="Marshal\Bitfield.cs" />
+    <Compile Include="Marshal\IPassByValue.cs" />
+    <Compile Include="Generation\Record.cs" />
+    <Compile Include="Generation\Member.cs" />
+    <Compile Include="Generation\Field.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Schema\c.xsd" />

--- a/src/Gir/Marshal/Field.cs
+++ b/src/Gir/Marshal/Field.cs
@@ -1,0 +1,7 @@
+﻿using System;
+namespace Gir
+{
+	public partial class Field : IHasType
+	{
+	}
+}

--- a/src/Gir/Marshal/IHasType.cs
+++ b/src/Gir/Marshal/IHasType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+namespace Gir
+{
+	public interface IHasType
+	{
+		Type Type { get; }
+	}
+
+	public static class IHasTypeExtensions
+	{
+		public static ISymbol GetSymbol(this IHasType type, GenerationOptions opts)
+		{
+			return opts.SymbolTable[type.Type.CType];
+		}
+	}
+}

--- a/src/Gir/Marshal/IPassByValue.cs
+++ b/src/Gir/Marshal/IPassByValue.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Gir
+{
+	public interface IPassByValue
+	{
+		string ByValueMarshalType { get; }
+	}
+}

--- a/src/Gir/Marshal/Namespace.cs
+++ b/src/Gir/Marshal/Namespace.cs
@@ -5,6 +5,6 @@ namespace Gir
 {
 	public partial class Namespace
 	{
-		public IEnumerable<ISymbol> GetSymbols() => Utils.GetAllCollectionMembers<ISymbol>(this);
+		public IEnumerable<ISymbol> GetSymbols() => Utils.GetAllCollectionMembers<ISymbol> (this);
 	}
 }

--- a/src/Gir/Marshal/Primitive.cs
+++ b/src/Gir/Marshal/Primitive.cs
@@ -7,6 +7,8 @@ namespace Gir
 		public string Name { get; }
 		public string DefaultValue { get; }
 
+		public string ByValueMarshalType => Name;
+
 		public Primitive(string ctype, string name, string defaultValue)
 		{
 			CType = ctype;

--- a/src/Gir/Marshal/SymbolTable.Builtin.cs
+++ b/src/Gir/Marshal/SymbolTable.Builtin.cs
@@ -7,6 +7,11 @@ namespace Gir
 		void RegisterBuiltIn(bool nativeWin64)
 		{
 			RegisterPrimitives(nativeWin64);
+
+			//AddType(new MarshalGen("time_t", "System.DateTime", "IntPtr", "GLib.Marshaller.DateTimeTotime_t ({0})", "GLib.Marshaller.time_tToDateTime ({0})"));
+			//AddType(new StringMarshalGen("gfilename", "string", "IntPtr", "GLib.Marshaller.StringToFilenamePtr({0})", "GLib.Marshaller.FilenamePtrToStringGFree({0})"));
+			//AddType(new StringMarshalGen("gchar", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
+			//AddType(new StringMarshalGen("char", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
 		}
 
 		void RegisterPrimitives (bool nativeWin64)
@@ -45,12 +50,6 @@ namespace Gir
 			AddType(new Primitive("gssize", "IntPtr", "IntPtr.Zero"));
 			AddType(new Primitive("size_t", "UIntPtr", "UIntPtr.Zero"));
 			AddType(new Primitive("gsize", "UIntPtr", "UIntPtr.Zero"));
-
-			// FIXME: Add these eventually.
-			//AddType(new MarshalGen("time_t", "System.DateTime", "IntPtr", "GLib.Marshaller.DateTimeTotime_t ({0})", "GLib.Marshaller.time_tToDateTime ({0})"));
-			//AddType(new StringMarshalGen("gfilename", "string", "IntPtr", "GLib.Marshaller.StringToFilenamePtr({0})", "GLib.Marshaller.FilenamePtrToStringGFree({0})"));
-			//AddType(new StringMarshalGen("gchar", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
-			//AddType(new StringMarshalGen("char", "string", "IntPtr", "GLib.Marshaller.StringToPtrGStrdup({0})", "GLib.Marshaller.PtrToStringGFree({0})"));
 
 			RegisterLongTypes(nativeWin64);
 		}

--- a/src/Gir/Marshal/Type.cs
+++ b/src/Gir/Marshal/Type.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Gir
+{
+	public partial class Type
+	{
+		public ISymbol GetSymbol (GenerationOptions opts)
+		{
+			return opts.SymbolTable[CType];
+		}
+	}
+}

--- a/src/Gir/Model/Field.cs
+++ b/src/Gir/Model/Field.cs
@@ -27,6 +27,6 @@ namespace Gir
 		public Documentation Doc;
 
 		[XmlElement("type")]
-		public Type Type;
+		public Type Type { get; set; }
 	}
 }

--- a/src/Gir/Model/Field.cs
+++ b/src/Gir/Model/Field.cs
@@ -23,6 +23,9 @@ namespace Gir
 		[XmlAttribute("writable")]
 		public bool Writable;
 
+		[XmlElement("doc")]
+		public Documentation Doc;
+
 		[XmlElement("type")]
 		public Type Type;
 	}

--- a/src/Gir/Model/Record.cs
+++ b/src/Gir/Model/Record.cs
@@ -21,7 +21,7 @@ namespace Gir
 		public bool Introspectable;
 
 		[XmlAttribute("name")]
-		public string Name;
+		public string Name { get; set; }
 
 		[XmlAttribute("version")]
 		public string Version;

--- a/src/Gir/Utils.cs
+++ b/src/Gir/Utils.cs
@@ -31,6 +31,7 @@ namespace Gir
 
 		internal static IEnumerable<T> GetAllCollectionMembers<T> (object container)
 		{
+			// This doesn't yield things like: <record><union/></record>
 			foreach (var collection in GetCollectionsOf<T>(container)) {
 				foreach (var item in collection)
 					yield return (T)item;


### PR DESCRIPTION
Move enum Member generation into Member, by implementing IMemberGeneratable
Interfaces will start to take shape, so top-level generate extension methods will handle full generation of a given IGeneratable
Simple IPassByValue implementation