### PR TITLE
Interface work

### DIFF
--- a/src/Gir.Tests/ClassTests.cs
+++ b/src/Gir.Tests/ClassTests.cs
@@ -50,9 +50,9 @@ namespace Gir.Tests
 		{
 		}
 
-		FilterOutputStream parent_instance;
+		FilterOutputStream ParentInstance;
 
-		BufferedOutputStreamPrivate priv;
+		BufferedOutputStreamPrivate Priv;
 
 		static extern bool g_buffered_output_stream_get_auto_grow PARAMS
 

--- a/src/Gir.Tests/ClassTests.cs
+++ b/src/Gir.Tests/ClassTests.cs
@@ -12,7 +12,6 @@ namespace Gir.Tests
 			// Test is incomplete, as record is not fully generated atm.
 			var result = GenerateType (Gio2, "BufferedOutputStream");
 
-
 			// Need to map pointers at symbol level.
 			Assert.AreEqual (@"namespace Gio
 {
@@ -61,13 +60,13 @@ namespace Gir.Tests
 		/// %TRUE if the @stream's buffer automatically grows,
 		/// %FALSE otherwise.
 		///</returns>
-		bool GetAutoGrow PARAMS
+		bool GetAutoGrow (BufferedOutputStream stream);
 
 		static extern UIntPtr g_buffered_output_stream_get_buffer_size PARAMS
 
 		///<summary>Gets the size of the buffer in the @stream.</summary>
 		///<returns>the current size of the buffer.</returns>
-		UIntPtr GetBufferSize PARAMS
+		UIntPtr GetBufferSize (BufferedOutputStream stream);
 
 		static extern void g_buffered_output_stream_set_auto_grow PARAMS
 
@@ -77,12 +76,12 @@ namespace Gir.Tests
 		/// larger, and you must manually flush the buffer to actually write out
 		/// the data to the underlying stream.
 		///</summary>
-		void SetAutoGrow PARAMS
+		void SetAutoGrow (BufferedOutputStream stream, gboolean auto_grow);
 
 		static extern void g_buffered_output_stream_set_buffer_size PARAMS
 
 		///<summary>Sets the size of the internal buffer to @size.</summary>
-		void SetBufferSize PARAMS
+		void SetBufferSize (BufferedOutputStream stream, gsize size);
 	}
 }
 ", result);

--- a/src/Gir.Tests/ClassTests.cs
+++ b/src/Gir.Tests/ClassTests.cs
@@ -33,7 +33,7 @@ namespace Gir.Tests
 	///</summary>
 	public class BufferedOutputStream : Seekable
 	{
-		static extern OutputStream g_buffered_output_stream_new PARAMS
+		static extern OutputStream g_buffered_output_stream_new (OutputStream base_stream)
 
 		///<summary>Creates a new buffered output stream for a base stream.</summary>
 		///<returns>a #GOutputStream for the given @base_stream.</returns>
@@ -41,7 +41,7 @@ namespace Gir.Tests
 		{
 		}
 
-		static extern OutputStream g_buffered_output_stream_new_sized PARAMS
+		static extern OutputStream g_buffered_output_stream_new_sized (OutputStream base_stream, gsize size)
 
 		///<summary>Creates a new buffered output stream with a given buffer size.</summary>
 		///<returns>a #GOutputStream with an internal buffer set to @size.</returns>
@@ -53,7 +53,7 @@ namespace Gir.Tests
 
 		BufferedOutputStreamPrivate Priv;
 
-		static extern bool g_buffered_output_stream_get_auto_grow PARAMS
+		static extern bool g_buffered_output_stream_get_auto_grow (BufferedOutputStream stream)
 
 		///<summary>Checks if the buffer automatically grows as data is added.</summary>
 		///<returns>
@@ -62,13 +62,13 @@ namespace Gir.Tests
 		///</returns>
 		bool GetAutoGrow (BufferedOutputStream stream);
 
-		static extern UIntPtr g_buffered_output_stream_get_buffer_size PARAMS
+		static extern UIntPtr g_buffered_output_stream_get_buffer_size (BufferedOutputStream stream)
 
 		///<summary>Gets the size of the buffer in the @stream.</summary>
 		///<returns>the current size of the buffer.</returns>
 		UIntPtr GetBufferSize (BufferedOutputStream stream);
 
-		static extern void g_buffered_output_stream_set_auto_grow PARAMS
+		static extern void g_buffered_output_stream_set_auto_grow (BufferedOutputStream stream, gboolean auto_grow)
 
 		///<summary>
 		/// Sets whether or not the @stream's buffer should automatically grow.
@@ -78,7 +78,7 @@ namespace Gir.Tests
 		///</summary>
 		void SetAutoGrow (BufferedOutputStream stream, gboolean auto_grow);
 
-		static extern void g_buffered_output_stream_set_buffer_size PARAMS
+		static extern void g_buffered_output_stream_set_buffer_size (BufferedOutputStream stream, gsize size)
 
 		///<summary>Sets the size of the internal buffer to @size.</summary>
 		void SetBufferSize (BufferedOutputStream stream, gsize size);

--- a/src/Gir.Tests/ClassTests.cs
+++ b/src/Gir.Tests/ClassTests.cs
@@ -33,7 +33,7 @@ namespace Gir.Tests
 	///</summary>
 	public class BufferedOutputStream : Seekable
 	{
-		static extern OutputStream g_buffered_output_stream_new (OutputStream base_stream)
+		static extern OutputStream g_buffered_output_stream_new (OutputStream base_stream);
 
 		///<summary>Creates a new buffered output stream for a base stream.</summary>
 		///<returns>a #GOutputStream for the given @base_stream.</returns>
@@ -41,7 +41,7 @@ namespace Gir.Tests
 		{
 		}
 
-		static extern OutputStream g_buffered_output_stream_new_sized (OutputStream base_stream, gsize size)
+		static extern OutputStream g_buffered_output_stream_new_sized (OutputStream base_stream, gsize size);
 
 		///<summary>Creates a new buffered output stream with a given buffer size.</summary>
 		///<returns>a #GOutputStream with an internal buffer set to @size.</returns>
@@ -53,7 +53,7 @@ namespace Gir.Tests
 
 		BufferedOutputStreamPrivate Priv;
 
-		static extern bool g_buffered_output_stream_get_auto_grow (BufferedOutputStream stream)
+		static extern bool g_buffered_output_stream_get_auto_grow (BufferedOutputStream stream);
 
 		///<summary>Checks if the buffer automatically grows as data is added.</summary>
 		///<returns>
@@ -62,13 +62,13 @@ namespace Gir.Tests
 		///</returns>
 		bool GetAutoGrow (BufferedOutputStream stream);
 
-		static extern UIntPtr g_buffered_output_stream_get_buffer_size (BufferedOutputStream stream)
+		static extern UIntPtr g_buffered_output_stream_get_buffer_size (BufferedOutputStream stream);
 
 		///<summary>Gets the size of the buffer in the @stream.</summary>
 		///<returns>the current size of the buffer.</returns>
 		UIntPtr GetBufferSize (BufferedOutputStream stream);
 
-		static extern void g_buffered_output_stream_set_auto_grow (BufferedOutputStream stream, gboolean auto_grow)
+		static extern void g_buffered_output_stream_set_auto_grow (BufferedOutputStream stream, gboolean auto_grow);
 
 		///<summary>
 		/// Sets whether or not the @stream's buffer should automatically grow.
@@ -78,7 +78,7 @@ namespace Gir.Tests
 		///</summary>
 		void SetAutoGrow (BufferedOutputStream stream, gboolean auto_grow);
 
-		static extern void g_buffered_output_stream_set_buffer_size (BufferedOutputStream stream, gsize size)
+		static extern void g_buffered_output_stream_set_buffer_size (BufferedOutputStream stream, gsize size);
 
 		///<summary>Sets the size of the internal buffer to @size.</summary>
 		void SetBufferSize (BufferedOutputStream stream, gsize size);

--- a/src/Gir.Tests/FunctionTests.cs
+++ b/src/Gir.Tests/FunctionTests.cs
@@ -19,7 +19,7 @@ namespace Gir.Tests
 /// The array will grow in size automatically if necessary.
 ///</summary>
 ///<returns>the #GByteArray</returns>
-static void Append PARAMS
+static void Append ( array, guint8 data, guint len);
 ", result);
 		}
 	}

--- a/src/Gir.Tests/FunctionTests.cs
+++ b/src/Gir.Tests/FunctionTests.cs
@@ -12,7 +12,7 @@ namespace Gir.Tests
 			// Test is incomplete, as record is not fully generated atm.
 			var result = GenerateMember (GLib, "ByteArray", "append");
 
-			Assert.AreEqual (@"static extern void g_byte_array_append ( array, guint8 data, guint len)
+			Assert.AreEqual (@"static extern void g_byte_array_append ( array, guint8 data, guint len);
 
 ///<summary>
 /// Adds the given bytes to the end of the #GByteArray.

--- a/src/Gir.Tests/FunctionTests.cs
+++ b/src/Gir.Tests/FunctionTests.cs
@@ -12,7 +12,7 @@ namespace Gir.Tests
 			// Test is incomplete, as record is not fully generated atm.
 			var result = GenerateMember (GLib, "ByteArray", "append");
 
-			Assert.AreEqual (@"static extern void g_byte_array_append PARAMS
+			Assert.AreEqual (@"static extern void g_byte_array_append ( array, guint8 data, guint len)
 
 ///<summary>
 /// Adds the given bytes to the end of the #GByteArray.

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -33,13 +33,13 @@ namespace Gir.Tests
 
 		///<summary>Tests if the stream supports the #GSeekableIface.</summary>
 		///<returns>%TRUE if @seekable can be seeked. %FALSE otherwise.</returns>
-		public bool CanSeek PARAMS
+		public bool CanSeek (Seekable seekable);
 
 		static extern bool g_seekable_can_truncate PARAMS
 
 		///<summary>Tests if the stream can be truncated.</summary>
 		///<returns>%TRUE if the stream can be truncated, %FALSE otherwise.</returns>
-		public bool CanTruncate PARAMS
+		public bool CanTruncate (Seekable seekable);
 
 		static extern bool g_seekable_seek PARAMS
 
@@ -64,13 +64,13 @@ namespace Gir.Tests
 		///     has occurred, this function will return %FALSE and set @error
 		///     appropriately if present.
 		///</returns>
-		public bool Seek PARAMS
+		public bool Seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
 		static extern long g_seekable_tell PARAMS
 
 		///<summary>Tells the current position within the stream.</summary>
 		///<returns>the offset from the beginning of the buffer.</returns>
-		public long Tell PARAMS
+		public long Tell (Seekable seekable);
 
 		static extern bool g_seekable_truncate PARAMS
 
@@ -88,7 +88,7 @@ namespace Gir.Tests
 		///     has occurred, this function will return %FALSE and set @error
 		///     appropriately if present.
 		///</returns>
-		public bool Truncate PARAMS
+		public bool Truncate (Seekable seekable, gint64 offset, Cancellable cancellable);
 	}
 }
 ", result);
@@ -104,23 +104,23 @@ namespace Gir.Tests
 	{
 		static extern bool g_seekable_can_seek PARAMS
 
-		public bool CanSeek PARAMS
+		public bool CanSeek (Seekable seekable);
 
 		static extern bool g_seekable_can_truncate PARAMS
 
-		public bool CanTruncate PARAMS
+		public bool CanTruncate (Seekable seekable);
 
 		static extern bool g_seekable_seek PARAMS
 
-		public bool Seek PARAMS
+		public bool Seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
 		static extern long g_seekable_tell PARAMS
 
-		public long Tell PARAMS
+		public long Tell (Seekable seekable);
 
 		static extern bool g_seekable_truncate PARAMS
 
-		public bool Truncate PARAMS
+		public bool Truncate (Seekable seekable, gint64 offset, Cancellable cancellable);
 	}
 }
 ", result);
@@ -157,7 +157,7 @@ namespace Gir.Tests
 		/// a handler id which can be used in atk_component_remove_focus_handler()
 		/// or zero if the handler was already added.
 		///</returns>
-		public uint AddFocusHandler PARAMS
+		public uint AddFocusHandler (Component component, FocusHandler handler);
 
 		static extern bool atk_component_contains PARAMS
 
@@ -172,7 +172,7 @@ namespace Gir.Tests
 		/// %TRUE or %FALSE indicating whether the specified point is within
 		/// the extent of the @component or not
 		///</returns>
-		public bool Contains PARAMS
+		public bool Contains (Component component, gint x, gint y, CoordType coord_type);
 
 		static extern double atk_component_get_alpha PARAMS
 
@@ -182,18 +182,18 @@ namespace Gir.Tests
 		/// (fully opaque).
 		///</summary>
 		///<returns>An alpha value from 0 to 1.0, inclusive.</returns>
-		public double GetAlpha PARAMS
+		public double GetAlpha (Component component);
 
 		static extern void atk_component_get_extents PARAMS
 
 		///<summary>Gets the rectangle which gives the extent of the @component.</summary>
-		public void GetExtents PARAMS
+		public void GetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
 		static extern Layer atk_component_get_layer PARAMS
 
 		///<summary>Gets the layer of the component.</summary>
 		///<returns>an #AtkLayer which is the layer of the component</returns>
-		public Layer GetLayer PARAMS
+		public Layer GetLayer (Component component);
 
 		static extern int atk_component_get_mdi_zorder PARAMS
 
@@ -206,7 +206,7 @@ namespace Gir.Tests
 		/// which the component is shown in relation to other components in the same
 		/// container.
 		///</returns>
-		public int GetMdiZorder PARAMS
+		public int GetMdiZorder (Component component);
 
 		static extern void atk_component_get_position PARAMS
 
@@ -214,18 +214,18 @@ namespace Gir.Tests
 		/// Gets the position of @component in the form of
 		/// a point specifying @component's top-left corner.
 		///</summary>
-		public void GetPosition PARAMS
+		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
 
 		static extern void atk_component_get_size PARAMS
 
 		///<summary>Gets the size of the @component in terms of width and height.</summary>
-		public void GetSize PARAMS
+		public void GetSize (Component component, gint width, gint height);
 
 		static extern bool atk_component_grab_focus PARAMS
 
 		///<summary>Grabs focus for this @component.</summary>
 		///<returns>%TRUE if successful, %FALSE otherwise.</returns>
-		public bool GrabFocus PARAMS
+		public bool GrabFocus (Component component);
 
 		static extern Object atk_component_ref_accessible_at_point PARAMS
 
@@ -237,7 +237,7 @@ namespace Gir.Tests
 		/// a reference to the accessible
 		/// child, if one exists
 		///</returns>
-		public Object RefAccessibleAtPoint PARAMS
+		public Object RefAccessibleAtPoint (Component component, gint x, gint y, CoordType coord_type);
 
 		static extern void atk_component_remove_focus_handler PARAMS
 
@@ -246,25 +246,94 @@ namespace Gir.Tests
 		/// functions to be executed when this object receives focus events
 		/// (in or out).
 		///</summary>
-		public void RemoveFocusHandler PARAMS
+		public void RemoveFocusHandler (Component component, guint handler_id);
 
 		static extern bool atk_component_set_extents PARAMS
 
 		///<summary>Sets the extents of @component.</summary>
 		///<returns>%TRUE or %FALSE whether the extents were set or not</returns>
-		public bool SetExtents PARAMS
+		public bool SetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
 		static extern bool atk_component_set_position PARAMS
 
 		///<summary>Sets the postition of @component.</summary>
 		///<returns>%TRUE or %FALSE whether or not the position was set or not</returns>
-		public bool SetPosition PARAMS
+		public bool SetPosition (Component component, gint x, gint y, CoordType coord_type);
 
 		static extern bool atk_component_set_size PARAMS
 
 		///<summary>Set the size of the @component in terms of width and height.</summary>
 		///<returns>%TRUE or %FALSE whether the size was set or not</returns>
-		public bool SetSize PARAMS
+		public bool SetSize (Component component, gint width, gint height);
+	}
+}
+", result);
+		}
+
+		[Test]
+		public void GenerateAtkComponentInterfaceCompat ()
+		{
+			var result = GenerateType (Atk1, "Component", true);
+
+			Assert.AreEqual (@"namespace Atk
+{
+	public interface Component
+	{
+		static extern uint atk_component_add_focus_handler PARAMS
+
+		public uint AddFocusHandler (Component component, FocusHandler handler);
+
+		static extern bool atk_component_contains PARAMS
+
+		public bool Contains (Component component, gint x, gint y, CoordType coord_type);
+
+		static extern double atk_component_get_alpha PARAMS
+
+		public double GetAlpha (Component component);
+
+		static extern void atk_component_get_extents PARAMS
+
+		public void GetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
+
+		static extern Layer atk_component_get_layer PARAMS
+
+		public Layer GetLayer (Component component);
+
+		static extern int atk_component_get_mdi_zorder PARAMS
+
+		public int GetMdiZorder (Component component);
+
+		static extern void atk_component_get_position PARAMS
+
+		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
+
+		static extern void atk_component_get_size PARAMS
+
+		public void GetSize (Component component, gint width, gint height);
+
+		static extern bool atk_component_grab_focus PARAMS
+
+		public bool GrabFocus (Component component);
+
+		static extern Object atk_component_ref_accessible_at_point PARAMS
+
+		public Object RefAccessibleAtPoint (Component component, gint x, gint y, CoordType coord_type);
+
+		static extern void atk_component_remove_focus_handler PARAMS
+
+		public void RemoveFocusHandler (Component component, guint handler_id);
+
+		static extern bool atk_component_set_extents PARAMS
+
+		public bool SetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
+
+		static extern bool atk_component_set_position PARAMS
+
+		public bool SetPosition (Component component, gint x, gint y, CoordType coord_type);
+
+		static extern bool atk_component_set_size PARAMS
+
+		public bool SetSize (Component component, gint width, gint height);
 	}
 }
 ", result);

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -153,6 +153,8 @@ namespace Gir.Tests
 		/// when this object receives focus events (in or out). If the handler is
 		/// already added it is not added again
 		///</summary>
+		[Obsolete (""(Version: 2.9.4) If you need to track when an object gains or
+lose the focus, use the #AtkObject::state-change ""focused"" notification instead."")]
 		///<returns>
 		/// a handler id which can be used in atk_component_remove_focus_handler()
 		/// or zero if the handler was already added.
@@ -214,11 +216,13 @@ namespace Gir.Tests
 		/// Gets the position of @component in the form of
 		/// a point specifying @component's top-left corner.
 		///</summary>
+		[Obsolete (""(Version: ) Since 2.12. Use atk_component_get_extents() instead."")]
 		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
 
 		static extern void atk_component_get_size (Component component, gint width, gint height);
 
 		///<summary>Gets the size of the @component in terms of width and height.</summary>
+		[Obsolete (""(Version: ) Since 2.12. Use atk_component_get_extents() instead."")]
 		public void GetSize (Component component, gint width, gint height);
 
 		static extern bool atk_component_grab_focus (Component component);
@@ -246,6 +250,8 @@ namespace Gir.Tests
 		/// functions to be executed when this object receives focus events
 		/// (in or out).
 		///</summary>
+		[Obsolete (""(Version: 2.9.4) If you need to track when an object gains or
+lose the focus, use the #AtkObject::state-change ""focused"" notification instead."")]
 		public void RemoveFocusHandler (Component component, guint handler_id);
 
 		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
@@ -281,6 +287,8 @@ namespace Gir.Tests
 	{
 		static extern uint atk_component_add_focus_handler (Component component, FocusHandler handler);
 
+		[Obsolete (""(Version: 2.9.4) If you need to track when an object gains or
+lose the focus, use the #AtkObject::state-change ""focused"" notification instead."")]
 		public uint AddFocusHandler (Component component, FocusHandler handler);
 
 		static extern bool atk_component_contains (Component component, gint x, gint y, CoordType coord_type);
@@ -305,10 +313,12 @@ namespace Gir.Tests
 
 		static extern void atk_component_get_position (Component component, gint x, gint y, CoordType coord_type);
 
+		[Obsolete (""(Version: ) Since 2.12. Use atk_component_get_extents() instead."")]
 		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
 
 		static extern void atk_component_get_size (Component component, gint width, gint height);
 
+		[Obsolete (""(Version: ) Since 2.12. Use atk_component_get_extents() instead."")]
 		public void GetSize (Component component, gint width, gint height);
 
 		static extern bool atk_component_grab_focus (Component component);
@@ -321,6 +331,8 @@ namespace Gir.Tests
 
 		static extern void atk_component_remove_focus_handler (Component component, guint handler_id);
 
+		[Obsolete (""(Version: 2.9.4) If you need to track when an object gains or
+lose the focus, use the #AtkObject::state-change ""focused"" notification instead."")]
 		public void RemoveFocusHandler (Component component, guint handler_id);
 
 		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -33,13 +33,13 @@ namespace Gir.Tests
 
 		///<summary>Tests if the stream supports the #GSeekableIface.</summary>
 		///<returns>%TRUE if @seekable can be seeked. %FALSE otherwise.</returns>
-		bool CanSeek PARAMS
+		public bool CanSeek PARAMS
 
 		static extern bool g_seekable_can_truncate PARAMS
 
 		///<summary>Tests if the stream can be truncated.</summary>
 		///<returns>%TRUE if the stream can be truncated, %FALSE otherwise.</returns>
-		bool CanTruncate PARAMS
+		public bool CanTruncate PARAMS
 
 		static extern bool g_seekable_seek PARAMS
 
@@ -64,13 +64,13 @@ namespace Gir.Tests
 		///     has occurred, this function will return %FALSE and set @error
 		///     appropriately if present.
 		///</returns>
-		bool Seek PARAMS
+		public bool Seek PARAMS
 
 		static extern long g_seekable_tell PARAMS
 
 		///<summary>Tells the current position within the stream.</summary>
 		///<returns>the offset from the beginning of the buffer.</returns>
-		long Tell PARAMS
+		public long Tell PARAMS
 
 		static extern bool g_seekable_truncate PARAMS
 
@@ -88,7 +88,7 @@ namespace Gir.Tests
 		///     has occurred, this function will return %FALSE and set @error
 		///     appropriately if present.
 		///</returns>
-		bool Truncate PARAMS
+		public bool Truncate PARAMS
 	}
 }
 ", result);
@@ -104,23 +104,23 @@ namespace Gir.Tests
 	{
 		static extern bool g_seekable_can_seek PARAMS
 
-		bool CanSeek PARAMS
+		public bool CanSeek PARAMS
 
 		static extern bool g_seekable_can_truncate PARAMS
 
-		bool CanTruncate PARAMS
+		public bool CanTruncate PARAMS
 
 		static extern bool g_seekable_seek PARAMS
 
-		bool Seek PARAMS
+		public bool Seek PARAMS
 
 		static extern long g_seekable_tell PARAMS
 
-		long Tell PARAMS
+		public long Tell PARAMS
 
 		static extern bool g_seekable_truncate PARAMS
 
-		bool Truncate PARAMS
+		public bool Truncate PARAMS
 	}
 }
 ", result);
@@ -157,7 +157,7 @@ namespace Gir.Tests
 		/// a handler id which can be used in atk_component_remove_focus_handler()
 		/// or zero if the handler was already added.
 		///</returns>
-		uint AddFocusHandler PARAMS
+		public uint AddFocusHandler PARAMS
 
 		static extern bool atk_component_contains PARAMS
 
@@ -172,7 +172,7 @@ namespace Gir.Tests
 		/// %TRUE or %FALSE indicating whether the specified point is within
 		/// the extent of the @component or not
 		///</returns>
-		bool Contains PARAMS
+		public bool Contains PARAMS
 
 		static extern double atk_component_get_alpha PARAMS
 
@@ -182,18 +182,18 @@ namespace Gir.Tests
 		/// (fully opaque).
 		///</summary>
 		///<returns>An alpha value from 0 to 1.0, inclusive.</returns>
-		double GetAlpha PARAMS
+		public double GetAlpha PARAMS
 
 		static extern void atk_component_get_extents PARAMS
 
 		///<summary>Gets the rectangle which gives the extent of the @component.</summary>
-		void GetExtents PARAMS
+		public void GetExtents PARAMS
 
 		static extern Layer atk_component_get_layer PARAMS
 
 		///<summary>Gets the layer of the component.</summary>
 		///<returns>an #AtkLayer which is the layer of the component</returns>
-		Layer GetLayer PARAMS
+		public Layer GetLayer PARAMS
 
 		static extern int atk_component_get_mdi_zorder PARAMS
 
@@ -206,7 +206,7 @@ namespace Gir.Tests
 		/// which the component is shown in relation to other components in the same
 		/// container.
 		///</returns>
-		int GetMdiZorder PARAMS
+		public int GetMdiZorder PARAMS
 
 		static extern void atk_component_get_position PARAMS
 
@@ -214,18 +214,18 @@ namespace Gir.Tests
 		/// Gets the position of @component in the form of
 		/// a point specifying @component's top-left corner.
 		///</summary>
-		void GetPosition PARAMS
+		public void GetPosition PARAMS
 
 		static extern void atk_component_get_size PARAMS
 
 		///<summary>Gets the size of the @component in terms of width and height.</summary>
-		void GetSize PARAMS
+		public void GetSize PARAMS
 
 		static extern bool atk_component_grab_focus PARAMS
 
 		///<summary>Grabs focus for this @component.</summary>
 		///<returns>%TRUE if successful, %FALSE otherwise.</returns>
-		bool GrabFocus PARAMS
+		public bool GrabFocus PARAMS
 
 		static extern Object atk_component_ref_accessible_at_point PARAMS
 
@@ -237,7 +237,7 @@ namespace Gir.Tests
 		/// a reference to the accessible
 		/// child, if one exists
 		///</returns>
-		Object RefAccessibleAtPoint PARAMS
+		public Object RefAccessibleAtPoint PARAMS
 
 		static extern void atk_component_remove_focus_handler PARAMS
 
@@ -246,25 +246,25 @@ namespace Gir.Tests
 		/// functions to be executed when this object receives focus events
 		/// (in or out).
 		///</summary>
-		void RemoveFocusHandler PARAMS
+		public void RemoveFocusHandler PARAMS
 
 		static extern bool atk_component_set_extents PARAMS
 
 		///<summary>Sets the extents of @component.</summary>
 		///<returns>%TRUE or %FALSE whether the extents were set or not</returns>
-		bool SetExtents PARAMS
+		public bool SetExtents PARAMS
 
 		static extern bool atk_component_set_position PARAMS
 
 		///<summary>Sets the postition of @component.</summary>
 		///<returns>%TRUE or %FALSE whether or not the position was set or not</returns>
-		bool SetPosition PARAMS
+		public bool SetPosition PARAMS
 
 		static extern bool atk_component_set_size PARAMS
 
 		///<summary>Set the size of the @component in terms of width and height.</summary>
 		///<returns>%TRUE or %FALSE whether the size was set or not</returns>
-		bool SetSize PARAMS
+		public bool SetSize PARAMS
 	}
 }
 ", result);

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -29,19 +29,19 @@ namespace Gir.Tests
 	///</summary>
 	public interface ISeekable
 	{
-		static extern bool g_seekable_can_seek (Seekable seekable)
+		static extern bool g_seekable_can_seek (Seekable seekable);
 
 		///<summary>Tests if the stream supports the #GSeekableIface.</summary>
 		///<returns>%TRUE if @seekable can be seeked. %FALSE otherwise.</returns>
 		public bool CanSeek (Seekable seekable);
 
-		static extern bool g_seekable_can_truncate (Seekable seekable)
+		static extern bool g_seekable_can_truncate (Seekable seekable);
 
 		///<summary>Tests if the stream can be truncated.</summary>
 		///<returns>%TRUE if the stream can be truncated, %FALSE otherwise.</returns>
 		public bool CanTruncate (Seekable seekable);
 
-		static extern bool g_seekable_seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable)
+		static extern bool g_seekable_seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
 		///<summary>
 		/// Seeks in the stream by the given @offset, modified by @type.
@@ -66,13 +66,13 @@ namespace Gir.Tests
 		///</returns>
 		public bool Seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
-		static extern long g_seekable_tell (Seekable seekable)
+		static extern long g_seekable_tell (Seekable seekable);
 
 		///<summary>Tells the current position within the stream.</summary>
 		///<returns>the offset from the beginning of the buffer.</returns>
 		public long Tell (Seekable seekable);
 
-		static extern bool g_seekable_truncate (Seekable seekable, gint64 offset, Cancellable cancellable)
+		static extern bool g_seekable_truncate (Seekable seekable, gint64 offset, Cancellable cancellable);
 
 		///<summary>
 		/// Truncates a stream with a given #offset.
@@ -102,23 +102,23 @@ namespace Gir.Tests
 {
 	public interface Seekable
 	{
-		static extern bool g_seekable_can_seek (Seekable seekable)
+		static extern bool g_seekable_can_seek (Seekable seekable);
 
 		public bool CanSeek (Seekable seekable);
 
-		static extern bool g_seekable_can_truncate (Seekable seekable)
+		static extern bool g_seekable_can_truncate (Seekable seekable);
 
 		public bool CanTruncate (Seekable seekable);
 
-		static extern bool g_seekable_seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable)
+		static extern bool g_seekable_seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
 		public bool Seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
-		static extern long g_seekable_tell (Seekable seekable)
+		static extern long g_seekable_tell (Seekable seekable);
 
 		public long Tell (Seekable seekable);
 
-		static extern bool g_seekable_truncate (Seekable seekable, gint64 offset, Cancellable cancellable)
+		static extern bool g_seekable_truncate (Seekable seekable, gint64 offset, Cancellable cancellable);
 
 		public bool Truncate (Seekable seekable, gint64 offset, Cancellable cancellable);
 	}
@@ -146,7 +146,7 @@ namespace Gir.Tests
 	///</summary>
 	public interface IComponent
 	{
-		static extern uint atk_component_add_focus_handler (Component component, FocusHandler handler)
+		static extern uint atk_component_add_focus_handler (Component component, FocusHandler handler);
 
 		///<summary>
 		/// Add the specified handler to the set of functions to be called
@@ -159,7 +159,7 @@ namespace Gir.Tests
 		///</returns>
 		public uint AddFocusHandler (Component component, FocusHandler handler);
 
-		static extern bool atk_component_contains (Component component, gint x, gint y, CoordType coord_type)
+		static extern bool atk_component_contains (Component component, gint x, gint y, CoordType coord_type);
 
 		///<summary>
 		/// Checks whether the specified point is within the extent of the @component.
@@ -174,7 +174,7 @@ namespace Gir.Tests
 		///</returns>
 		public bool Contains (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern double atk_component_get_alpha (Component component)
+		static extern double atk_component_get_alpha (Component component);
 
 		///<summary>
 		/// Returns the alpha value (i.e. the opacity) for this
@@ -184,18 +184,18 @@ namespace Gir.Tests
 		///<returns>An alpha value from 0 to 1.0, inclusive.</returns>
 		public double GetAlpha (Component component);
 
-		static extern void atk_component_get_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
+		static extern void atk_component_get_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
 		///<summary>Gets the rectangle which gives the extent of the @component.</summary>
 		public void GetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern Layer atk_component_get_layer (Component component)
+		static extern Layer atk_component_get_layer (Component component);
 
 		///<summary>Gets the layer of the component.</summary>
 		///<returns>an #AtkLayer which is the layer of the component</returns>
 		public Layer GetLayer (Component component);
 
-		static extern int atk_component_get_mdi_zorder (Component component)
+		static extern int atk_component_get_mdi_zorder (Component component);
 
 		///<summary>
 		/// Gets the zorder of the component. The value G_MININT will be returned
@@ -208,7 +208,7 @@ namespace Gir.Tests
 		///</returns>
 		public int GetMdiZorder (Component component);
 
-		static extern void atk_component_get_position (Component component, gint x, gint y, CoordType coord_type)
+		static extern void atk_component_get_position (Component component, gint x, gint y, CoordType coord_type);
 
 		///<summary>
 		/// Gets the position of @component in the form of
@@ -216,18 +216,18 @@ namespace Gir.Tests
 		///</summary>
 		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_get_size (Component component, gint width, gint height)
+		static extern void atk_component_get_size (Component component, gint width, gint height);
 
 		///<summary>Gets the size of the @component in terms of width and height.</summary>
 		public void GetSize (Component component, gint width, gint height);
 
-		static extern bool atk_component_grab_focus (Component component)
+		static extern bool atk_component_grab_focus (Component component);
 
 		///<summary>Grabs focus for this @component.</summary>
 		///<returns>%TRUE if successful, %FALSE otherwise.</returns>
 		public bool GrabFocus (Component component);
 
-		static extern Object atk_component_ref_accessible_at_point (Component component, gint x, gint y, CoordType coord_type)
+		static extern Object atk_component_ref_accessible_at_point (Component component, gint x, gint y, CoordType coord_type);
 
 		///<summary>
 		/// Gets a reference to the accessible child, if one exists, at the
@@ -239,7 +239,7 @@ namespace Gir.Tests
 		///</returns>
 		public Object RefAccessibleAtPoint (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_remove_focus_handler (Component component, guint handler_id)
+		static extern void atk_component_remove_focus_handler (Component component, guint handler_id);
 
 		///<summary>
 		/// Remove the handler specified by @handler_id from the list of
@@ -248,19 +248,19 @@ namespace Gir.Tests
 		///</summary>
 		public void RemoveFocusHandler (Component component, guint handler_id);
 
-		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
+		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
 		///<summary>Sets the extents of @component.</summary>
 		///<returns>%TRUE or %FALSE whether the extents were set or not</returns>
 		public bool SetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern bool atk_component_set_position (Component component, gint x, gint y, CoordType coord_type)
+		static extern bool atk_component_set_position (Component component, gint x, gint y, CoordType coord_type);
 
 		///<summary>Sets the postition of @component.</summary>
 		///<returns>%TRUE or %FALSE whether or not the position was set or not</returns>
 		public bool SetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern bool atk_component_set_size (Component component, gint width, gint height)
+		static extern bool atk_component_set_size (Component component, gint width, gint height);
 
 		///<summary>Set the size of the @component in terms of width and height.</summary>
 		///<returns>%TRUE or %FALSE whether the size was set or not</returns>
@@ -279,59 +279,59 @@ namespace Gir.Tests
 {
 	public interface Component
 	{
-		static extern uint atk_component_add_focus_handler (Component component, FocusHandler handler)
+		static extern uint atk_component_add_focus_handler (Component component, FocusHandler handler);
 
 		public uint AddFocusHandler (Component component, FocusHandler handler);
 
-		static extern bool atk_component_contains (Component component, gint x, gint y, CoordType coord_type)
+		static extern bool atk_component_contains (Component component, gint x, gint y, CoordType coord_type);
 
 		public bool Contains (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern double atk_component_get_alpha (Component component)
+		static extern double atk_component_get_alpha (Component component);
 
 		public double GetAlpha (Component component);
 
-		static extern void atk_component_get_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
+		static extern void atk_component_get_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
 		public void GetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern Layer atk_component_get_layer (Component component)
+		static extern Layer atk_component_get_layer (Component component);
 
 		public Layer GetLayer (Component component);
 
-		static extern int atk_component_get_mdi_zorder (Component component)
+		static extern int atk_component_get_mdi_zorder (Component component);
 
 		public int GetMdiZorder (Component component);
 
-		static extern void atk_component_get_position (Component component, gint x, gint y, CoordType coord_type)
+		static extern void atk_component_get_position (Component component, gint x, gint y, CoordType coord_type);
 
 		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_get_size (Component component, gint width, gint height)
+		static extern void atk_component_get_size (Component component, gint width, gint height);
 
 		public void GetSize (Component component, gint width, gint height);
 
-		static extern bool atk_component_grab_focus (Component component)
+		static extern bool atk_component_grab_focus (Component component);
 
 		public bool GrabFocus (Component component);
 
-		static extern Object atk_component_ref_accessible_at_point (Component component, gint x, gint y, CoordType coord_type)
+		static extern Object atk_component_ref_accessible_at_point (Component component, gint x, gint y, CoordType coord_type);
 
 		public Object RefAccessibleAtPoint (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_remove_focus_handler (Component component, guint handler_id)
+		static extern void atk_component_remove_focus_handler (Component component, guint handler_id);
 
 		public void RemoveFocusHandler (Component component, guint handler_id);
 
-		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
+		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
 		public bool SetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern bool atk_component_set_position (Component component, gint x, gint y, CoordType coord_type)
+		static extern bool atk_component_set_position (Component component, gint x, gint y, CoordType coord_type);
 
 		public bool SetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern bool atk_component_set_size (Component component, gint width, gint height)
+		static extern bool atk_component_set_size (Component component, gint width, gint height);
 
 		public bool SetSize (Component component, gint width, gint height);
 	}

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -27,7 +27,7 @@ namespace Gir.Tests
 	/// lseek() on a normal file.  Seeking past the end and writing data will
 	/// usually cause the stream to resize by introducing zero bytes.
 	///</summary>
-	public interface Seekable
+	public interface ISeekable
 	{
 		static extern bool g_seekable_can_seek PARAMS
 
@@ -89,6 +89,182 @@ namespace Gir.Tests
 		///     appropriately if present.
 		///</returns>
 		bool Truncate PARAMS
+	}
+}
+", result);
+		}
+
+		[Test]
+		public void TestSeekableInterfaceIsGeneratedCompatEnabled()
+		{
+			var result = GenerateType(Gio2, "Seekable", true);
+			Assert.AreEqual(@"namespace Gio
+{
+	public interface Seekable
+	{
+		static extern bool g_seekable_can_seek PARAMS
+
+		bool CanSeek PARAMS
+
+		static extern bool g_seekable_can_truncate PARAMS
+
+		bool CanTruncate PARAMS
+
+		static extern bool g_seekable_seek PARAMS
+
+		bool Seek PARAMS
+
+		static extern long g_seekable_tell PARAMS
+
+		long Tell PARAMS
+
+		static extern bool g_seekable_truncate PARAMS
+
+		bool Truncate PARAMS
+	}
+}
+", result);
+		}
+
+		[Test]
+		public void GenerateAtkComponentInterface ()
+		{
+			var result = GenerateType(Atk1, "Component");
+			Assert.AreEqual(@"namespace Atk
+{
+	///<summary>
+	/// #AtkComponent should be implemented by most if not all UI elements
+	/// with an actual on-screen presence, i.e. components which can be
+	/// said to have a screen-coordinate bounding box.  Virtually all
+	/// widgets will need to have #AtkComponent implementations provided
+	/// for their corresponding #AtkObject class.  In short, only UI
+	/// elements which are *not* GUI elements will omit this ATK interface.
+	/// 
+	/// A possible exception might be textual information with a
+	/// transparent background, in which case text glyph bounding box
+	/// information is provided by #AtkText.
+	///</summary>
+	public interface IComponent
+	{
+		static extern uint atk_component_add_focus_handler PARAMS
+
+		///<summary>
+		/// Add the specified handler to the set of functions to be called
+		/// when this object receives focus events (in or out). If the handler is
+		/// already added it is not added again
+		///</summary>
+		///<returns>
+		/// a handler id which can be used in atk_component_remove_focus_handler()
+		/// or zero if the handler was already added.
+		///</returns>
+		uint AddFocusHandler PARAMS
+
+		static extern bool atk_component_contains PARAMS
+
+		///<summary>
+		/// Checks whether the specified point is within the extent of the @component.
+		/// 
+		/// Toolkit implementor note: ATK provides a default implementation for
+		/// this virtual method. In general there are little reason to
+		/// re-implement it.
+		///</summary>
+		///<returns>
+		/// %TRUE or %FALSE indicating whether the specified point is within
+		/// the extent of the @component or not
+		///</returns>
+		bool Contains PARAMS
+
+		static extern double atk_component_get_alpha PARAMS
+
+		///<summary>
+		/// Returns the alpha value (i.e. the opacity) for this
+		/// @component, on a scale from 0 (fully transparent) to 1.0
+		/// (fully opaque).
+		///</summary>
+		///<returns>An alpha value from 0 to 1.0, inclusive.</returns>
+		double GetAlpha PARAMS
+
+		static extern void atk_component_get_extents PARAMS
+
+		///<summary>Gets the rectangle which gives the extent of the @component.</summary>
+		void GetExtents PARAMS
+
+		static extern Layer atk_component_get_layer PARAMS
+
+		///<summary>Gets the layer of the component.</summary>
+		///<returns>an #AtkLayer which is the layer of the component</returns>
+		Layer GetLayer PARAMS
+
+		static extern int atk_component_get_mdi_zorder PARAMS
+
+		///<summary>
+		/// Gets the zorder of the component. The value G_MININT will be returned
+		/// if the layer of the component is not ATK_LAYER_MDI or ATK_LAYER_WINDOW.
+		///</summary>
+		///<returns>
+		/// a gint which is the zorder of the component, i.e. the depth at
+		/// which the component is shown in relation to other components in the same
+		/// container.
+		///</returns>
+		int GetMdiZorder PARAMS
+
+		static extern void atk_component_get_position PARAMS
+
+		///<summary>
+		/// Gets the position of @component in the form of
+		/// a point specifying @component's top-left corner.
+		///</summary>
+		void GetPosition PARAMS
+
+		static extern void atk_component_get_size PARAMS
+
+		///<summary>Gets the size of the @component in terms of width and height.</summary>
+		void GetSize PARAMS
+
+		static extern bool atk_component_grab_focus PARAMS
+
+		///<summary>Grabs focus for this @component.</summary>
+		///<returns>%TRUE if successful, %FALSE otherwise.</returns>
+		bool GrabFocus PARAMS
+
+		static extern Object atk_component_ref_accessible_at_point PARAMS
+
+		///<summary>
+		/// Gets a reference to the accessible child, if one exists, at the
+		/// coordinate point specified by @x and @y.
+		///</summary>
+		///<returns>
+		/// a reference to the accessible
+		/// child, if one exists
+		///</returns>
+		Object RefAccessibleAtPoint PARAMS
+
+		static extern void atk_component_remove_focus_handler PARAMS
+
+		///<summary>
+		/// Remove the handler specified by @handler_id from the list of
+		/// functions to be executed when this object receives focus events
+		/// (in or out).
+		///</summary>
+		void RemoveFocusHandler PARAMS
+
+		static extern bool atk_component_set_extents PARAMS
+
+		///<summary>Sets the extents of @component.</summary>
+		///<returns>%TRUE or %FALSE whether the extents were set or not</returns>
+		bool SetExtents PARAMS
+
+		static extern bool atk_component_set_position PARAMS
+
+		///<summary>Sets the postition of @component.</summary>
+		///<returns>%TRUE or %FALSE whether or not the position was set or not</returns>
+		bool SetPosition PARAMS
+
+		static extern bool atk_component_set_size PARAMS
+
+		///<summary>Set the size of the @component in terms of width and height.</summary>
+		///<returns>%TRUE or %FALSE whether the size was set or not</returns>
+		bool SetSize PARAMS
 	}
 }
 ", result);

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -271,6 +271,8 @@ lose the focus, use the #AtkObject::state-change ""focused"" notification instea
 		///<summary>Set the size of the @component in terms of width and height.</summary>
 		///<returns>%TRUE or %FALSE whether the size was set or not</returns>
 		public bool SetSize (Component component, gint width, gint height);
+
+		event Bounds-changed;
 	}
 }
 ", result);
@@ -346,6 +348,8 @@ lose the focus, use the #AtkObject::state-change ""focused"" notification instea
 		static extern bool atk_component_set_size (Component component, gint width, gint height);
 
 		public bool SetSize (Component component, gint width, gint height);
+
+		event Bounds-changed;
 	}
 }
 ", result);

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -29,19 +29,19 @@ namespace Gir.Tests
 	///</summary>
 	public interface ISeekable
 	{
-		static extern bool g_seekable_can_seek PARAMS
+		static extern bool g_seekable_can_seek (Seekable seekable)
 
 		///<summary>Tests if the stream supports the #GSeekableIface.</summary>
 		///<returns>%TRUE if @seekable can be seeked. %FALSE otherwise.</returns>
 		public bool CanSeek (Seekable seekable);
 
-		static extern bool g_seekable_can_truncate PARAMS
+		static extern bool g_seekable_can_truncate (Seekable seekable)
 
 		///<summary>Tests if the stream can be truncated.</summary>
 		///<returns>%TRUE if the stream can be truncated, %FALSE otherwise.</returns>
 		public bool CanTruncate (Seekable seekable);
 
-		static extern bool g_seekable_seek PARAMS
+		static extern bool g_seekable_seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable)
 
 		///<summary>
 		/// Seeks in the stream by the given @offset, modified by @type.
@@ -66,13 +66,13 @@ namespace Gir.Tests
 		///</returns>
 		public bool Seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
-		static extern long g_seekable_tell PARAMS
+		static extern long g_seekable_tell (Seekable seekable)
 
 		///<summary>Tells the current position within the stream.</summary>
 		///<returns>the offset from the beginning of the buffer.</returns>
 		public long Tell (Seekable seekable);
 
-		static extern bool g_seekable_truncate PARAMS
+		static extern bool g_seekable_truncate (Seekable seekable, gint64 offset, Cancellable cancellable)
 
 		///<summary>
 		/// Truncates a stream with a given #offset.
@@ -102,23 +102,23 @@ namespace Gir.Tests
 {
 	public interface Seekable
 	{
-		static extern bool g_seekable_can_seek PARAMS
+		static extern bool g_seekable_can_seek (Seekable seekable)
 
 		public bool CanSeek (Seekable seekable);
 
-		static extern bool g_seekable_can_truncate PARAMS
+		static extern bool g_seekable_can_truncate (Seekable seekable)
 
 		public bool CanTruncate (Seekable seekable);
 
-		static extern bool g_seekable_seek PARAMS
+		static extern bool g_seekable_seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable)
 
 		public bool Seek (Seekable seekable, gint64 offset, GLib.SeekType type, Cancellable cancellable);
 
-		static extern long g_seekable_tell PARAMS
+		static extern long g_seekable_tell (Seekable seekable)
 
 		public long Tell (Seekable seekable);
 
-		static extern bool g_seekable_truncate PARAMS
+		static extern bool g_seekable_truncate (Seekable seekable, gint64 offset, Cancellable cancellable)
 
 		public bool Truncate (Seekable seekable, gint64 offset, Cancellable cancellable);
 	}
@@ -146,7 +146,7 @@ namespace Gir.Tests
 	///</summary>
 	public interface IComponent
 	{
-		static extern uint atk_component_add_focus_handler PARAMS
+		static extern uint atk_component_add_focus_handler (Component component, FocusHandler handler)
 
 		///<summary>
 		/// Add the specified handler to the set of functions to be called
@@ -159,7 +159,7 @@ namespace Gir.Tests
 		///</returns>
 		public uint AddFocusHandler (Component component, FocusHandler handler);
 
-		static extern bool atk_component_contains PARAMS
+		static extern bool atk_component_contains (Component component, gint x, gint y, CoordType coord_type)
 
 		///<summary>
 		/// Checks whether the specified point is within the extent of the @component.
@@ -174,7 +174,7 @@ namespace Gir.Tests
 		///</returns>
 		public bool Contains (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern double atk_component_get_alpha PARAMS
+		static extern double atk_component_get_alpha (Component component)
 
 		///<summary>
 		/// Returns the alpha value (i.e. the opacity) for this
@@ -184,18 +184,18 @@ namespace Gir.Tests
 		///<returns>An alpha value from 0 to 1.0, inclusive.</returns>
 		public double GetAlpha (Component component);
 
-		static extern void atk_component_get_extents PARAMS
+		static extern void atk_component_get_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
 
 		///<summary>Gets the rectangle which gives the extent of the @component.</summary>
 		public void GetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern Layer atk_component_get_layer PARAMS
+		static extern Layer atk_component_get_layer (Component component)
 
 		///<summary>Gets the layer of the component.</summary>
 		///<returns>an #AtkLayer which is the layer of the component</returns>
 		public Layer GetLayer (Component component);
 
-		static extern int atk_component_get_mdi_zorder PARAMS
+		static extern int atk_component_get_mdi_zorder (Component component)
 
 		///<summary>
 		/// Gets the zorder of the component. The value G_MININT will be returned
@@ -208,7 +208,7 @@ namespace Gir.Tests
 		///</returns>
 		public int GetMdiZorder (Component component);
 
-		static extern void atk_component_get_position PARAMS
+		static extern void atk_component_get_position (Component component, gint x, gint y, CoordType coord_type)
 
 		///<summary>
 		/// Gets the position of @component in the form of
@@ -216,18 +216,18 @@ namespace Gir.Tests
 		///</summary>
 		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_get_size PARAMS
+		static extern void atk_component_get_size (Component component, gint width, gint height)
 
 		///<summary>Gets the size of the @component in terms of width and height.</summary>
 		public void GetSize (Component component, gint width, gint height);
 
-		static extern bool atk_component_grab_focus PARAMS
+		static extern bool atk_component_grab_focus (Component component)
 
 		///<summary>Grabs focus for this @component.</summary>
 		///<returns>%TRUE if successful, %FALSE otherwise.</returns>
 		public bool GrabFocus (Component component);
 
-		static extern Object atk_component_ref_accessible_at_point PARAMS
+		static extern Object atk_component_ref_accessible_at_point (Component component, gint x, gint y, CoordType coord_type)
 
 		///<summary>
 		/// Gets a reference to the accessible child, if one exists, at the
@@ -239,7 +239,7 @@ namespace Gir.Tests
 		///</returns>
 		public Object RefAccessibleAtPoint (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_remove_focus_handler PARAMS
+		static extern void atk_component_remove_focus_handler (Component component, guint handler_id)
 
 		///<summary>
 		/// Remove the handler specified by @handler_id from the list of
@@ -248,19 +248,19 @@ namespace Gir.Tests
 		///</summary>
 		public void RemoveFocusHandler (Component component, guint handler_id);
 
-		static extern bool atk_component_set_extents PARAMS
+		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
 
 		///<summary>Sets the extents of @component.</summary>
 		///<returns>%TRUE or %FALSE whether the extents were set or not</returns>
 		public bool SetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern bool atk_component_set_position PARAMS
+		static extern bool atk_component_set_position (Component component, gint x, gint y, CoordType coord_type)
 
 		///<summary>Sets the postition of @component.</summary>
 		///<returns>%TRUE or %FALSE whether or not the position was set or not</returns>
 		public bool SetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern bool atk_component_set_size PARAMS
+		static extern bool atk_component_set_size (Component component, gint width, gint height)
 
 		///<summary>Set the size of the @component in terms of width and height.</summary>
 		///<returns>%TRUE or %FALSE whether the size was set or not</returns>
@@ -279,59 +279,59 @@ namespace Gir.Tests
 {
 	public interface Component
 	{
-		static extern uint atk_component_add_focus_handler PARAMS
+		static extern uint atk_component_add_focus_handler (Component component, FocusHandler handler)
 
 		public uint AddFocusHandler (Component component, FocusHandler handler);
 
-		static extern bool atk_component_contains PARAMS
+		static extern bool atk_component_contains (Component component, gint x, gint y, CoordType coord_type)
 
 		public bool Contains (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern double atk_component_get_alpha PARAMS
+		static extern double atk_component_get_alpha (Component component)
 
 		public double GetAlpha (Component component);
 
-		static extern void atk_component_get_extents PARAMS
+		static extern void atk_component_get_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
 
 		public void GetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern Layer atk_component_get_layer PARAMS
+		static extern Layer atk_component_get_layer (Component component)
 
 		public Layer GetLayer (Component component);
 
-		static extern int atk_component_get_mdi_zorder PARAMS
+		static extern int atk_component_get_mdi_zorder (Component component)
 
 		public int GetMdiZorder (Component component);
 
-		static extern void atk_component_get_position PARAMS
+		static extern void atk_component_get_position (Component component, gint x, gint y, CoordType coord_type)
 
 		public void GetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_get_size PARAMS
+		static extern void atk_component_get_size (Component component, gint width, gint height)
 
 		public void GetSize (Component component, gint width, gint height);
 
-		static extern bool atk_component_grab_focus PARAMS
+		static extern bool atk_component_grab_focus (Component component)
 
 		public bool GrabFocus (Component component);
 
-		static extern Object atk_component_ref_accessible_at_point PARAMS
+		static extern Object atk_component_ref_accessible_at_point (Component component, gint x, gint y, CoordType coord_type)
 
 		public Object RefAccessibleAtPoint (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern void atk_component_remove_focus_handler PARAMS
+		static extern void atk_component_remove_focus_handler (Component component, guint handler_id)
 
 		public void RemoveFocusHandler (Component component, guint handler_id);
 
-		static extern bool atk_component_set_extents PARAMS
+		static extern bool atk_component_set_extents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type)
 
 		public bool SetExtents (Component component, gint x, gint y, gint width, gint height, CoordType coord_type);
 
-		static extern bool atk_component_set_position PARAMS
+		static extern bool atk_component_set_position (Component component, gint x, gint y, CoordType coord_type)
 
 		public bool SetPosition (Component component, gint x, gint y, CoordType coord_type);
 
-		static extern bool atk_component_set_size PARAMS
+		static extern bool atk_component_set_size (Component component, gint width, gint height)
 
 		public bool SetSize (Component component, gint width, gint height);
 	}

--- a/src/Gir.Tests/InterfaceTests.cs
+++ b/src/Gir.Tests/InterfaceTests.cs
@@ -6,14 +6,10 @@ namespace Gir.Tests
 	[TestFixture]
 	public class InterfaceTests : GenerationTestBase
 	{
-		[Test]
-		public void TestClassIsGenerated ()
+		public void TestSeekableInterfaceIsGenerated()
 		{
-			// Test is incomplete, as record is not fully generated atm.
-			var result = GenerateType (Gio2, "Seekable");
-
-			// Need to map pointers at symbol level.
-			Assert.AreEqual (@"namespace Gio
+			var result = GenerateType(Gio2, "Seekable");
+			Assert.AreEqual(@"namespace Gio
 {
 	///<summary>
 	/// #GSeekable is implemented by streams (implementations of

--- a/src/Gir.Tests/RecordTests.cs
+++ b/src/Gir.Tests/RecordTests.cs
@@ -35,7 +35,7 @@ namespace Gir.Tests
 		/// The array will grow in size automatically if necessary.
 		///</summary>
 		///<returns>the #GByteArray</returns>
-		static void Append PARAMS
+		static void Append ( array, guint8 data, guint len);
 
 		static extern byte g_byte_array_free PARAMS
 
@@ -49,7 +49,7 @@ namespace Gir.Tests
 		/// the element data if @free_segment is %FALSE, otherwise
 		///          %NULL.  The element data should be freed using g_free().
 		///</returns>
-		static byte Free PARAMS
+		static byte Free ( array, gboolean free_segment);
 
 		static extern Bytes g_byte_array_free_to_bytes PARAMS
 
@@ -67,13 +67,13 @@ namespace Gir.Tests
 		/// a new immutable #GBytes representing same
 		///     byte data that was in the array
 		///</returns>
-		static Bytes FreeToBytes PARAMS
+		static Bytes FreeToBytes ( array);
 
 		static extern void g_byte_array_new PARAMS
 
 		///<summary>Creates a new #GByteArray with a reference count of 1.</summary>
 		///<returns>the new #GByteArray</returns>
-		static void New PARAMS
+		static void New ();
 
 		static extern void g_byte_array_new_take PARAMS
 
@@ -82,7 +82,7 @@ namespace Gir.Tests
 		/// and will be freed with g_free(), i.e. it could be allocated using g_strdup().
 		///</summary>
 		///<returns>a new #GByteArray</returns>
-		static void NewTake PARAMS
+		static void NewTake ( data, gsize len);
 
 		static extern void g_byte_array_prepend PARAMS
 
@@ -91,7 +91,7 @@ namespace Gir.Tests
 		/// The array will grow in size automatically if necessary.
 		///</summary>
 		///<returns>the #GByteArray</returns>
-		static void Prepend PARAMS
+		static void Prepend ( array, guint8 data, guint len);
 
 		static extern void g_byte_array_ref PARAMS
 
@@ -100,7 +100,7 @@ namespace Gir.Tests
 		/// This function is thread-safe and may be called from any thread.
 		///</summary>
 		///<returns>The passed in #GByteArray</returns>
-		static void Ref PARAMS
+		static void Ref ( array);
 
 		static extern void g_byte_array_remove_index PARAMS
 
@@ -109,7 +109,7 @@ namespace Gir.Tests
 		/// The following bytes are moved down one place.
 		///</summary>
 		///<returns>the #GByteArray</returns>
-		static void RemoveIndex PARAMS
+		static void RemoveIndex ( array, guint index_);
 
 		static extern void g_byte_array_remove_index_fast PARAMS
 
@@ -120,7 +120,7 @@ namespace Gir.Tests
 		/// than g_byte_array_remove_index().
 		///</summary>
 		///<returns>the #GByteArray</returns>
-		static void RemoveIndexFast PARAMS
+		static void RemoveIndexFast ( array, guint index_);
 
 		static extern void g_byte_array_remove_range PARAMS
 
@@ -129,13 +129,13 @@ namespace Gir.Tests
 		/// #GByteArray.  The following elements are moved to close the gap.
 		///</summary>
 		///<returns>the #GByteArray</returns>
-		static void RemoveRange PARAMS
+		static void RemoveRange ( array, guint index_, guint length);
 
 		static extern void g_byte_array_set_size PARAMS
 
 		///<summary>Sets the size of the #GByteArray, expanding it if necessary.</summary>
 		///<returns>the #GByteArray</returns>
-		static void SetSize PARAMS
+		static void SetSize ( array, guint length);
 
 		static extern void g_byte_array_sized_new PARAMS
 
@@ -146,7 +146,7 @@ namespace Gir.Tests
 		/// 0.
 		///</summary>
 		///<returns>the new #GByteArray</returns>
-		static void SizedNew PARAMS
+		static void SizedNew (guint reserved_size);
 
 		static extern void g_byte_array_sort PARAMS
 
@@ -162,7 +162,7 @@ namespace Gir.Tests
 		/// if two elements would otherwise compare equal, compares them by
 		/// their addresses.
 		///</summary>
-		static void Sort PARAMS
+		static void Sort ( array, CompareFunc compare_func);
 
 		static extern void g_byte_array_sort_with_data PARAMS
 
@@ -170,7 +170,7 @@ namespace Gir.Tests
 		/// Like g_byte_array_sort(), but the comparison function takes an extra
 		/// user data argument.
 		///</summary>
-		static void SortWithData PARAMS
+		static void SortWithData ( array, CompareDataFunc compare_func, gpointer user_data);
 
 		static extern void g_byte_array_unref PARAMS
 
@@ -180,7 +180,7 @@ namespace Gir.Tests
 		/// released. This function is thread-safe and may be called from any
 		/// thread.
 		///</summary>
-		static void Unref PARAMS
+		static void Unref ( array);
 	}
 }
 ", result);

--- a/src/Gir.Tests/RecordTests.cs
+++ b/src/Gir.Tests/RecordTests.cs
@@ -185,18 +185,18 @@ namespace Gir.Tests
 ", result);
 		}
 
-		[Test]
-		[Ignore ("This currently fails. NRE w/ do_action field")]
-		public void CanGenerateActionIfaceRecord ()
-		{
-			// Test is incomplete, as record is not fully generated atm.
-			var result = GenerateType (Atk1, "ActionIface");
+//		[Test]
+//		[Ignore ("This currently fails. NRE w/ do_action field")]
+//		public void CanGenerateActionIfaceRecord ()
+//		{
+//			// Test is incomplete, as record is not fully generated atm.
+//			var result = GenerateType(Atk1, "ActionIface");
 
 
-			// Need to map pointers at symbol level.
-			Assert.AreEqual (@"namespace Atk
-{
-}", result);
-		}
+//			// Need to map pointers at symbol level.
+//			Assert.AreEqual(@"namespace Atk
+//{
+//}", result);
+//}
 	}
 }

--- a/src/Gir.Tests/RecordTests.cs
+++ b/src/Gir.Tests/RecordTests.cs
@@ -23,10 +23,10 @@ namespace Gir.Tests
 		/// a pointer to the element data. The data may be moved as
 		///     elements are added to the #GByteArray
 		///</summary>
-		byte data;
+		byte Data;
 
 		///<summary>the number of elements in the #GByteArray</summary>
-		uint len;
+		uint Len;
 
 		static extern void g_byte_array_append PARAMS
 

--- a/src/Gir.Tests/RecordTests.cs
+++ b/src/Gir.Tests/RecordTests.cs
@@ -12,7 +12,6 @@ namespace Gir.Tests
 			// Test is incomplete, as record is not fully generated atm.
 			var result = GenerateType (GLib, "ByteArray");
 
-
 			// Need to map pointers at symbol level.
 			Assert.AreEqual (@"namespace GLib
 {
@@ -28,7 +27,7 @@ namespace Gir.Tests
 		///<summary>the number of elements in the #GByteArray</summary>
 		uint Len;
 
-		static extern void g_byte_array_append PARAMS
+		static extern void g_byte_array_append ( array, guint8 data, guint len)
 
 		///<summary>
 		/// Adds the given bytes to the end of the #GByteArray.
@@ -37,7 +36,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void Append ( array, guint8 data, guint len);
 
-		static extern byte g_byte_array_free PARAMS
+		static extern byte g_byte_array_free ( array, gboolean free_segment)
 
 		///<summary>
 		/// Frees the memory allocated by the #GByteArray. If @free_segment is
@@ -51,7 +50,7 @@ namespace Gir.Tests
 		///</returns>
 		static byte Free ( array, gboolean free_segment);
 
-		static extern Bytes g_byte_array_free_to_bytes PARAMS
+		static extern Bytes g_byte_array_free_to_bytes ( array)
 
 		///<summary>
 		/// Transfers the data from the #GByteArray into a new immutable #GBytes.
@@ -69,13 +68,13 @@ namespace Gir.Tests
 		///</returns>
 		static Bytes FreeToBytes ( array);
 
-		static extern void g_byte_array_new PARAMS
+		static extern void g_byte_array_new ()
 
 		///<summary>Creates a new #GByteArray with a reference count of 1.</summary>
 		///<returns>the new #GByteArray</returns>
 		static void New ();
 
-		static extern void g_byte_array_new_take PARAMS
+		static extern void g_byte_array_new_take ( data, gsize len)
 
 		///<summary>
 		/// Create byte array containing the data. The data will be owned by the array
@@ -84,7 +83,7 @@ namespace Gir.Tests
 		///<returns>a new #GByteArray</returns>
 		static void NewTake ( data, gsize len);
 
-		static extern void g_byte_array_prepend PARAMS
+		static extern void g_byte_array_prepend ( array, guint8 data, guint len)
 
 		///<summary>
 		/// Adds the given data to the start of the #GByteArray.
@@ -93,7 +92,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void Prepend ( array, guint8 data, guint len);
 
-		static extern void g_byte_array_ref PARAMS
+		static extern void g_byte_array_ref ( array)
 
 		///<summary>
 		/// Atomically increments the reference count of @array by one.
@@ -102,7 +101,7 @@ namespace Gir.Tests
 		///<returns>The passed in #GByteArray</returns>
 		static void Ref ( array);
 
-		static extern void g_byte_array_remove_index PARAMS
+		static extern void g_byte_array_remove_index ( array, guint index_)
 
 		///<summary>
 		/// Removes the byte at the given index from a #GByteArray.
@@ -111,7 +110,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void RemoveIndex ( array, guint index_);
 
-		static extern void g_byte_array_remove_index_fast PARAMS
+		static extern void g_byte_array_remove_index_fast ( array, guint index_)
 
 		///<summary>
 		/// Removes the byte at the given index from a #GByteArray. The last
@@ -122,7 +121,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void RemoveIndexFast ( array, guint index_);
 
-		static extern void g_byte_array_remove_range PARAMS
+		static extern void g_byte_array_remove_range ( array, guint index_, guint length)
 
 		///<summary>
 		/// Removes the given number of bytes starting at the given index from a
@@ -131,13 +130,13 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void RemoveRange ( array, guint index_, guint length);
 
-		static extern void g_byte_array_set_size PARAMS
+		static extern void g_byte_array_set_size ( array, guint length)
 
 		///<summary>Sets the size of the #GByteArray, expanding it if necessary.</summary>
 		///<returns>the #GByteArray</returns>
 		static void SetSize ( array, guint length);
 
-		static extern void g_byte_array_sized_new PARAMS
+		static extern void g_byte_array_sized_new (guint reserved_size)
 
 		///<summary>
 		/// Creates a new #GByteArray with @reserved_size bytes preallocated.
@@ -148,7 +147,7 @@ namespace Gir.Tests
 		///<returns>the new #GByteArray</returns>
 		static void SizedNew (guint reserved_size);
 
-		static extern void g_byte_array_sort PARAMS
+		static extern void g_byte_array_sort ( array, CompareFunc compare_func)
 
 		///<summary>
 		/// Sorts a byte array, using @compare_func which should be a
@@ -164,7 +163,7 @@ namespace Gir.Tests
 		///</summary>
 		static void Sort ( array, CompareFunc compare_func);
 
-		static extern void g_byte_array_sort_with_data PARAMS
+		static extern void g_byte_array_sort_with_data ( array, CompareDataFunc compare_func, gpointer user_data)
 
 		///<summary>
 		/// Like g_byte_array_sort(), but the comparison function takes an extra
@@ -172,7 +171,7 @@ namespace Gir.Tests
 		///</summary>
 		static void SortWithData ( array, CompareDataFunc compare_func, gpointer user_data);
 
-		static extern void g_byte_array_unref PARAMS
+		static extern void g_byte_array_unref ( array)
 
 		///<summary>
 		/// Atomically decrements the reference count of @array by one. If the

--- a/src/Gir.Tests/RecordTests.cs
+++ b/src/Gir.Tests/RecordTests.cs
@@ -27,7 +27,7 @@ namespace Gir.Tests
 		///<summary>the number of elements in the #GByteArray</summary>
 		uint Len;
 
-		static extern void g_byte_array_append ( array, guint8 data, guint len)
+		static extern void g_byte_array_append ( array, guint8 data, guint len);
 
 		///<summary>
 		/// Adds the given bytes to the end of the #GByteArray.
@@ -36,7 +36,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void Append ( array, guint8 data, guint len);
 
-		static extern byte g_byte_array_free ( array, gboolean free_segment)
+		static extern byte g_byte_array_free ( array, gboolean free_segment);
 
 		///<summary>
 		/// Frees the memory allocated by the #GByteArray. If @free_segment is
@@ -50,7 +50,7 @@ namespace Gir.Tests
 		///</returns>
 		static byte Free ( array, gboolean free_segment);
 
-		static extern Bytes g_byte_array_free_to_bytes ( array)
+		static extern Bytes g_byte_array_free_to_bytes ( array);
 
 		///<summary>
 		/// Transfers the data from the #GByteArray into a new immutable #GBytes.
@@ -68,13 +68,13 @@ namespace Gir.Tests
 		///</returns>
 		static Bytes FreeToBytes ( array);
 
-		static extern void g_byte_array_new ()
+		static extern void g_byte_array_new ();
 
 		///<summary>Creates a new #GByteArray with a reference count of 1.</summary>
 		///<returns>the new #GByteArray</returns>
 		static void New ();
 
-		static extern void g_byte_array_new_take ( data, gsize len)
+		static extern void g_byte_array_new_take ( data, gsize len);
 
 		///<summary>
 		/// Create byte array containing the data. The data will be owned by the array
@@ -83,7 +83,7 @@ namespace Gir.Tests
 		///<returns>a new #GByteArray</returns>
 		static void NewTake ( data, gsize len);
 
-		static extern void g_byte_array_prepend ( array, guint8 data, guint len)
+		static extern void g_byte_array_prepend ( array, guint8 data, guint len);
 
 		///<summary>
 		/// Adds the given data to the start of the #GByteArray.
@@ -92,7 +92,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void Prepend ( array, guint8 data, guint len);
 
-		static extern void g_byte_array_ref ( array)
+		static extern void g_byte_array_ref ( array);
 
 		///<summary>
 		/// Atomically increments the reference count of @array by one.
@@ -101,7 +101,7 @@ namespace Gir.Tests
 		///<returns>The passed in #GByteArray</returns>
 		static void Ref ( array);
 
-		static extern void g_byte_array_remove_index ( array, guint index_)
+		static extern void g_byte_array_remove_index ( array, guint index_);
 
 		///<summary>
 		/// Removes the byte at the given index from a #GByteArray.
@@ -110,7 +110,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void RemoveIndex ( array, guint index_);
 
-		static extern void g_byte_array_remove_index_fast ( array, guint index_)
+		static extern void g_byte_array_remove_index_fast ( array, guint index_);
 
 		///<summary>
 		/// Removes the byte at the given index from a #GByteArray. The last
@@ -121,7 +121,7 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void RemoveIndexFast ( array, guint index_);
 
-		static extern void g_byte_array_remove_range ( array, guint index_, guint length)
+		static extern void g_byte_array_remove_range ( array, guint index_, guint length);
 
 		///<summary>
 		/// Removes the given number of bytes starting at the given index from a
@@ -130,13 +130,13 @@ namespace Gir.Tests
 		///<returns>the #GByteArray</returns>
 		static void RemoveRange ( array, guint index_, guint length);
 
-		static extern void g_byte_array_set_size ( array, guint length)
+		static extern void g_byte_array_set_size ( array, guint length);
 
 		///<summary>Sets the size of the #GByteArray, expanding it if necessary.</summary>
 		///<returns>the #GByteArray</returns>
 		static void SetSize ( array, guint length);
 
-		static extern void g_byte_array_sized_new (guint reserved_size)
+		static extern void g_byte_array_sized_new (guint reserved_size);
 
 		///<summary>
 		/// Creates a new #GByteArray with @reserved_size bytes preallocated.
@@ -147,7 +147,7 @@ namespace Gir.Tests
 		///<returns>the new #GByteArray</returns>
 		static void SizedNew (guint reserved_size);
 
-		static extern void g_byte_array_sort ( array, CompareFunc compare_func)
+		static extern void g_byte_array_sort ( array, CompareFunc compare_func);
 
 		///<summary>
 		/// Sorts a byte array, using @compare_func which should be a
@@ -163,7 +163,7 @@ namespace Gir.Tests
 		///</summary>
 		static void Sort ( array, CompareFunc compare_func);
 
-		static extern void g_byte_array_sort_with_data ( array, CompareDataFunc compare_func, gpointer user_data)
+		static extern void g_byte_array_sort_with_data ( array, CompareDataFunc compare_func, gpointer user_data);
 
 		///<summary>
 		/// Like g_byte_array_sort(), but the comparison function takes an extra
@@ -171,7 +171,7 @@ namespace Gir.Tests
 		///</summary>
 		static void SortWithData ( array, CompareDataFunc compare_func, gpointer user_data);
 
-		static extern void g_byte_array_unref ( array)
+		static extern void g_byte_array_unref ( array);
 
 		///<summary>
 		/// Atomically decrements the reference count of @array by one. If the

--- a/src/Gir/Generation/Field.cs
+++ b/src/Gir/Generation/Field.cs
@@ -12,7 +12,7 @@ namespace Gir
 			// including the number of pointers.
 			// For now, generate normal info.
 
-			writer.WriteLine ($"{managedType.CSharpType} {Name};");
+			writer.WriteLine($"{managedType.CSharpType} {Name.ToCSharp ()};");
 		}
 
 		public bool NewlineAfterGeneration (GenerationOptions opts) => true;

--- a/src/Gir/Generation/IGeneratableExtensions.cs
+++ b/src/Gir/Generation/IGeneratableExtensions.cs
@@ -70,8 +70,10 @@ namespace Gir
 			var returnType = callable.GetReturnCSharpType (writer);
 
 			// generate ReturnValue then Parameters
-			writer.Write (string.Format ("{0} {1} {2}", returnType, callable.Name.ToCSharp (), "PARAMS"));
-			writer.WriteLine ();
+			// FIXME, probably don't need the instance parameters?
+			var (typesAndNames, names) = BuildParameters (callable.Parameters);
+			writer.Write(string.Format("{0} {1} ({2});", returnType, callable.Name.ToCSharp (), typesAndNames));
+			writer.WriteLine();
 		}
 
 		public static void GenerateConstructor (this ICallable callable, IGeneratable parent, IndentWriter writer)
@@ -96,12 +98,13 @@ namespace Gir
 
 		public static (string both, string names) BuildParameters (List<Parameter> parameters)
 		{
+			// FIXME, Arrays don't have a 'Type' set
 			// PERF: Use an array as the string[] overload of Join is way more efficient than the IEnumerable<string> one.
 			var typeAndName = new string [parameters.Count];
 			var parameterNames = new string [parameters.Count];
 			for (int i = 0; i < parameters.Count; ++i) {
 				var parameter = parameters [i];
-				typeAndName [i] = parameter.Type.Name + " " + parameter.Name;
+				typeAndName [i] = parameter.Type?.Name + " " + parameter.Name;
 				parameterNames [i] = parameter.Name;
 			}
 

--- a/src/Gir/Generation/IGeneratableExtensions.cs
+++ b/src/Gir/Generation/IGeneratableExtensions.cs
@@ -49,7 +49,8 @@ namespace Gir
 		{
 			var retType = GetReturnCSharpType (callable, writer);
 
-			writer.WriteLine ($"static extern {retType} {callable.CIdentifier} PARAMS");
+			var (typesAndNames, names) = BuildParameters (callable.Parameters);
+			writer.WriteLine ($"static extern {retType} {callable.CIdentifier} ({typesAndNames})");
 			writer.WriteLine ();
 		}
 
@@ -72,8 +73,8 @@ namespace Gir
 			// generate ReturnValue then Parameters
 			// FIXME, probably don't need the instance parameters?
 			var (typesAndNames, names) = BuildParameters (callable.Parameters);
-			writer.Write(string.Format("{0} {1} ({2});", returnType, callable.Name.ToCSharp (), typesAndNames));
-			writer.WriteLine();
+			writer.Write (string.Format ("{0} {1} ({2});", returnType, callable.Name.ToCSharp (), typesAndNames));
+			writer.WriteLine ();
 		}
 
 		public static void GenerateConstructor (this ICallable callable, IGeneratable parent, IndentWriter writer)

--- a/src/Gir/Generation/IGeneratableExtensions.cs
+++ b/src/Gir/Generation/IGeneratableExtensions.cs
@@ -50,7 +50,7 @@ namespace Gir
 			var retType = GetReturnCSharpType (callable, writer);
 
 			var (typesAndNames, names) = BuildParameters (callable.Parameters);
-			writer.WriteLine ($"static extern {retType} {callable.CIdentifier} ({typesAndNames})");
+			writer.WriteLine ($"static extern {retType} {callable.CIdentifier} ({typesAndNames});");
 			writer.WriteLine ();
 		}
 

--- a/src/Gir/Generation/Interface.cs
+++ b/src/Gir/Generation/Interface.cs
@@ -3,7 +3,6 @@ namespace Gir
 {
 	public partial class Interface : IGeneratable, IDocumented
 	{
-		// TODO, We should probably add 'I' to 'Name' unless in compat mode
 		public void Generate (GenerationOptions opts)
 		{
 			using (var writer = this.GetWriter (opts)) {
@@ -11,7 +10,8 @@ namespace Gir
 				writer.WriteLine ("{");
 				using (writer.Indent ()) {
 					this.GenerateDocumentation (writer);
-					writer.WriteLine ($"public interface {Name}");
+					var interfaceName = (opts.Compat) ? Name : $"I{Name}";
+					writer.WriteLine ($"public interface {interfaceName}");
 					writer.WriteLine ("{");
 
 					using (writer.Indent ()) {

--- a/src/Gir/Generation/Interface.cs
+++ b/src/Gir/Generation/Interface.cs
@@ -10,7 +10,7 @@ namespace Gir
 				writer.WriteLine ("{");
 				using (writer.Indent ()) {
 					this.GenerateDocumentation (writer);
-					var interfaceName = (opts.Compat) ? Name : $"I{Name}";
+					var interfaceName = (opts.GenerateInterfacesWithIPrefix) ? $"I{Name}" : Name;
 					writer.WriteLine ($"public interface {interfaceName}");
 					writer.WriteLine ("{");
 

--- a/src/Gir/Generation/Method.cs
+++ b/src/Gir/Generation/Method.cs
@@ -1,4 +1,5 @@
-﻿
+using System;
+
 namespace Gir
 {
 	public partial class Method : ICallable
@@ -10,7 +11,10 @@ namespace Gir
 			if (parent is Interface)
 				Modifiers = "public";
 
-			this.GenerateCallableDefinition(writer);
+			if (Deprecated)
+				writer.WriteLine ($"[Obsolete (\"(Version: {DeprecatedVersion}) {DocDeprecated.Text}\")]");
+
+			this.GenerateCallableDefinition (writer);
 		}
 
 		public bool NewlineAfterGeneration (GenerationOptions opts) => true;

--- a/src/Gir/Generation/Method.cs
+++ b/src/Gir/Generation/Method.cs
@@ -3,11 +3,14 @@ namespace Gir
 {
 	public partial class Method : ICallable
 	{
-		public string Modifiers => string.Empty;
+		public string Modifiers { get; set; }
 
 		public void Generate (IGeneratable parent, IndentWriter writer)
 		{
-			this.GenerateCallableDefinition (writer);
+			if (parent is Interface)
+				Modifiers = "public";
+
+			this.GenerateCallableDefinition(writer);
 		}
 
 		public bool NewlineAfterGeneration (GenerationOptions opts) => true;

--- a/src/Gir/Generation/Property.cs
+++ b/src/Gir/Generation/Property.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Gir
+{
+	public partial class Property : IGeneratable, IDocumented
+	{
+		public void Generate (GenerationOptions opts)
+		{
+		}
+	}
+}

--- a/src/Gir/Generation/Signal.cs
+++ b/src/Gir/Generation/Signal.cs
@@ -1,0 +1,41 @@
+
+namespace Gir
+{
+	public partial class Signal : IMemberGeneratable, IDocumented
+	{
+		public void Generate(IGeneratable parent, IndentWriter writer)
+		{
+			// FIXME, Signal isn't being populated correctly
+			//writer.WriteLine($"event {EventHandlerQualifiedName(parent)} {Name.ToCSharp()};");
+			writer.WriteLine ($"event {Name.ToCSharp ()};");
+		}
+
+		bool IsEventHandler {
+			get {
+				return ReturnValue.Type.Name == "void" && Parameters.Count == 1;// && (Parameters[0] is Object || Parameters[0] is Interface);
+			}
+		}
+
+		string EventHandlerQualifiedName (IGeneratable parent)
+		{
+			if (IsEventHandler)
+				return "System.EventHandler";
+
+			return parent.Name + "." + EventHandlerName;
+		}
+
+		public bool NewlineAfterGeneration (GenerationOptions opts) => true;
+
+		string EventHandlerName {
+			get {
+				if (IsEventHandler)
+					return "EventHandler";
+
+				//if (SymbolTable.Table[container_type.NS + Name + "Handler"] != null)
+					//return Name + "EventHandler";
+
+				return Name + "Handler";
+			}
+		}
+	}
+}

--- a/src/Gir/GenerationOptions.cs
+++ b/src/Gir/GenerationOptions.cs
@@ -19,8 +19,8 @@ namespace Gir
 		#endregion
 
 		#region Generation toggles
-		readonly bool compat;
-		public bool GenerateDocumentation { get { return !compat; } }
+		public bool Compat { get; }
+		public bool GenerateDocumentation { get { return !Compat; } }
 
 		// Try to find better logic for detecting this.
 		public bool NativeWin64 { get; }
@@ -34,7 +34,7 @@ namespace Gir
 		{
 			DirectoryPath = dir;
 			Repository = repo;
-			this.compat = compat;
+			Compat = compat;
 			RedirectStream = redirectStream;
 
 			SymbolTable = new SymbolTable (Statistics, win64Longs);

--- a/src/Gir/GenerationOptions.cs
+++ b/src/Gir/GenerationOptions.cs
@@ -19,8 +19,9 @@ namespace Gir
 		#endregion
 
 		#region Generation toggles
-		public bool Compat { get; }
-		public bool GenerateDocumentation { get { return !Compat; } }
+		readonly bool compat;
+		public bool GenerateDocumentation => !compat;
+		public bool GenerateInterfacesWithIPrefix => !compat;
 
 		// Try to find better logic for detecting this.
 		public bool NativeWin64 { get; }
@@ -34,7 +35,7 @@ namespace Gir
 		{
 			DirectoryPath = dir;
 			Repository = repo;
-			Compat = compat;
+			this.compat = compat;
 			RedirectStream = redirectStream;
 
 			SymbolTable = new SymbolTable (Statistics, win64Longs);

--- a/src/Gir/Gir.csproj
+++ b/src/Gir/Gir.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Marshal\Interface.cs" />
     <Compile Include="Generation\Constructor.cs" />
     <Compile Include="Generation\Property.cs" />
+    <Compile Include="Generation\Signal.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Schema\c.xsd" />

--- a/src/Gir/Gir.csproj
+++ b/src/Gir/Gir.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Generation\Interface.cs" />
     <Compile Include="Marshal\Interface.cs" />
     <Compile Include="Generation\Constructor.cs" />
+    <Compile Include="Generation\Property.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Schema\c.xsd" />

--- a/src/Gir/Gir.csproj
+++ b/src/Gir/Gir.csproj
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -77,6 +76,7 @@
     <Compile Include="Generation\IGeneratable.cs" />
     <Compile Include="Generation\Namespace.cs" />
     <Compile Include="Generation\Enumeration.cs" />
+    <Compile Include="Generation\Field.cs" />
     <Compile Include="Generation\IndentWriter.cs" />
     <Compile Include="GenerationOptions.cs" />
     <Compile Include="Generation\Bitfield.cs" />
@@ -98,7 +98,6 @@
     <Compile Include="Marshal\IPassByValue.cs" />
     <Compile Include="Generation\Record.cs" />
     <Compile Include="Generation\Member.cs" />
-    <Compile Include="Generation\Field.cs" />
     <Compile Include="Marshal\Type.cs" />
     <Compile Include="Marshal\IHasType.cs" />
     <Compile Include="Marshal\Field.cs" />

--- a/src/Gir/Model/Method.cs
+++ b/src/Gir/Model/Method.cs
@@ -38,7 +38,10 @@ namespace Gir
 		[XmlElement ("doc")]
 		public Documentation Doc { get; set; }
 
-		[XmlElement ("return-value")]
+		[XmlElement("doc-deprecated")]
+		public Documentation DocDeprecated { get; set; }
+
+		[XmlElement("return-value")]
 		public ReturnValue ReturnValue { get; set; }
 
 		[XmlArray ("parameters")]

--- a/src/Gir/Model/Property.cs
+++ b/src/Gir/Model/Property.cs
@@ -20,7 +20,7 @@ namespace Gir
 		public bool Introspectable;
 
 		[XmlAttribute ("name")]
-		public string Name;
+		public string Name { get; set; }
 
 		[XmlAttribute ("readable")]
 		public bool Readable;

--- a/src/Gir/Model/Signal.cs
+++ b/src/Gir/Model/Signal.cs
@@ -21,7 +21,7 @@ namespace Gir
 		public bool Introspectable;
 
 		[XmlAttribute ("name")]
-		public string Name;
+		public string Name { get; set; }
 
 		[XmlAttribute ("no-hooks")]
 		public bool NoHooks;
@@ -45,6 +45,5 @@ namespace Gir
 		[XmlArrayItem ("parameter", Type = typeof (Parameter))]
 		[XmlArrayItem ("instance-parameter", Type = typeof (InstanceParameter))]
 		public List<Parameter> Parameters { get; set; }
-
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/mono/gir-sharp/issues/35

* Interface members are now public
* Methods have parameters shown now
* Methods are flagged as obsolete w/ `doc-deprecated` text
* Basic signal stubs

Problems
* Instance parameters are included
* Array doesn't have `Type` set so you get 
   `static void Append ( array, guint8 data, guint len);`
* Not all deprecated versions have a version. Sometimes it seems to be in the `doc-deprecated` message
* Signal isn't being populated
* Parameters don't take ref, out, etc into account
