### PR TITLE
Fix typo when creating SymbolTable

### DIFF
--- a/src/Gir/GenerationOptions.cs
+++ b/src/Gir/GenerationOptions.cs
@@ -52,7 +52,7 @@ namespace Gir
 			// This may contain multiple libraries, so get the first one. Also, hack a string.Empty for xlib.
 			LibraryName = repo.Namespace.SharedLibrary?.Split (',') [0] ?? "";
 
-			SymbolTable = new SymbolTable(Statistics, options.Win64Longs);
+			SymbolTable = new SymbolTable(Statistics, Options.Win64Longs);
 
 			// Register the main repository once without namespace names and once with them.
 			SymbolTable.AddTypes (repo.GetSymbols());


### PR DESCRIPTION
`options` can be null.
https://github.com/mono/gir-sharp/blob/146296cfb118949874fb1af35d8681bdc2297aae/src/Gir/GenerationOptions.cs#L42

Should be `Options`
https://github.com/mono/gir-sharp/blob/146296cfb118949874fb1af35d8681bdc2297aae/src/Gir/GenerationOptions.cs#L45