### PR TITLE
Set the line ending to be unix

### DIFF
--- a/src/Gir.Tests/GenerationTestBase.cs
+++ b/src/Gir.Tests/GenerationTestBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -75,6 +75,8 @@ namespace Gir.Tests
 				Compat = compat,
 				RedirectStream = new MemoryStream (),
 				WriteHeader = !generateMember,
+				// Note, all of the tests assume "\n" and not "\r\n"
+				NewLine = "\n"
 			});
 		}
 

--- a/src/Gir/Generation/IndentWriter.cs
+++ b/src/Gir/Generation/IndentWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace Gir
@@ -13,7 +13,9 @@ namespace Gir
 		public static IndentWriter OpenWrite (string path, GenerationOptions opts)
 		{
 			var toStream = opts.RedirectStream ?? File.Open (path, FileMode.Create);
-			var sw = new StreamWriter (toStream);
+			var sw = new StreamWriter (toStream) {
+				NewLine = opts.NewLine
+			};
 
 			return new IndentWriter (sw) {
 				Options = opts,

--- a/src/Gir/GenerationOptions.cs
+++ b/src/Gir/GenerationOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -29,6 +29,8 @@ namespace Gir
 
 		// Try to find better logic for detecting this.
 		public bool NativeWin64 => Options.Win64Longs;
+
+		public string NewLine => Options.NewLine;
 		#endregion
 
 		#region Symbols
@@ -68,6 +70,7 @@ namespace Gir
 			public Stream RedirectStream;
 			public bool Win64Longs;
 			public bool WriteHeader = true;
+			public string NewLine = Environment.NewLine;
 		}
 	}
 }


### PR DESCRIPTION
All of the tests assume a line ending of \n and not \r\n.
This causes all of the tests to fail on Windows.